### PR TITLE
Provide the option to run puppet from cron vs a service.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ else
 end
 
 gem 'rake'
+gem 'pry'
 gem 'puppet-lint'
 gem 'rspec-puppet'
 gem 'puppetlabs_spec_helper'

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,16 +1,41 @@
 # # puppet agent service
 
-class puppet::agent (
-  $enable = 'running',
-  $ensure = true) inherits puppet::params {
+class puppet::agent (){
+  include ::puppet
+  if $::puppet::enabled {
+    #we want puppet enabled
+    case $::puppet::enable_mechanism {
+      'service': {
+        #we want puppet enabled as a service
+        $cron_enablement    = 'absent'
+        $service_enablement = true
+      }
+      'cron': {
+        $cron_enablement    = 'present'
+        $service_enablement = false
+      }
+      default: {
+        #noop. should never happen.
+      }
+    }
 
-  #input validation
-#  validate_bool($ensure)
-#  validate_string($enable)
+  } else {
+    #$::puppet::enabled is false
+    $cron_enablement    = 'absent'
+    $service_enablement = false
+  }
+
+  cron {"run_puppet_agent":
+    ensure  => $cron_enablement,
+    command => 'puppet agent -t',
+    special => 'absent',
+    minute  => $::puppet::agent_cron_min_interpolated,
+    hour    => $::puppet::agent_cron_hour_interpolated,
+  }
 
   service { 'puppet':
-    ensure  => $ensure,
-    enable  => $enable,
+    ensure  => $service_enablement,
+    enable  => $service_enablement,
     require => Class['puppet::config']
   }
 

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -24,15 +24,15 @@ describe 'puppet::agent', :type => :class do
 #      end
 #    end#arrays
 
-    ['ensure'].each do |bools|
-      context "when the #{bools} parameter is not an boolean" do
-        let (:params) {{bools => "BOGON"}}
-        it 'should fail' do
-          pending 'waiting on clarity of this params type'
-          expect { subject }.to raise_error(Puppet::Error, /"BOGON" is not a boolean.  It looks to be a String/)
-        end
-      end
-    end#bools
+#    ['bools'].each do |bools|
+#      context "when the #{bools} parameter is not an boolean" do
+#        let (:params) {{bools => "BOGON"}}
+#        it 'should fail' do
+#          pending 'waiting on clarity of this params type'
+#          expect { subject }.to raise_error(Puppet::Error, /"BOGON" is not a boolean.  It looks to be a String/)
+#        end
+#      end
+#    end#bools
 
 #    ['hash'].each do |hashes|
 #      context "when the #{hashes} parameter is not an hash" do
@@ -43,26 +43,167 @@ describe 'puppet::agent', :type => :class do
 #      end
 #    end#hashes
 
-    ['enable'].each do |strings|
-      context "when the #{strings} parameter is not a string" do
-        let (:params) {{strings => false }}
-        it 'should fail' do
-          pending 'waiting on clarity of this params type'
-          expect { subject }.to raise_error(Puppet::Error, /false is not a string./)
-        end
-      end
-    end#strings
-
+#    ['strings'].each do |strings|
+#      context "when the #{strings} parameter is not a string" do
+#        let (:params) {{strings => false }}
+#        it 'should fail' do
+#          pending 'waiting on clarity of this params type'
+#          expect { subject }.to raise_error(Puppet::Error, /false is not a string./)
+#        end
+#      end
+#    end#strings
   end#input validation
   context "When on a Debian system" do
-    let (:facts) {{'osfamily' => 'Debian'}}
-    context 'when fed no parameters' do
-      it 'should contain the puppet service with our default parameters' do
+    let (:facts) {{'osfamily' => 'Debian','fqdn' => 'testy.hosty.com', 'lsbdistid' => 'Debian', 'lsbdistcodename' => 'trusty'}}
+    context 'when puppet has default agent parameters' do
+      let (:pre_condition){"class{'::puppet':}"}
+      #let (:pre_condition) {"class{'puppet::master::install': hiera_eyaml_version=>'present' }"}
+      it 'should contain the puppet agent cronjob, in a disabled state' do
+        should contain_cron('run_puppet_agent').with({
+         :name=>"run_puppet_agent",
+         :ensure=>"absent",
+         :command=>"puppet agent -t",
+         :special=>"absent"
+        })
+       end
+      it 'should contain the puppet service, enabled, per default parameters' do
         should contain_service('puppet').with({
           :ensure=>true,
-          :enable=>"running"
+          :enable=>true,
         }).that_requires('Class[Puppet::Config]')
       end
     end#no params
+    context 'when $::puppet::enabled is true' do
+      context 'when $::puppet::enable_mechanism is service' do
+        let (:pre_condition){"class{'::puppet': enabled => true, enable_mechanism => 'service'}"}
+        it 'should contain the puppet agent cronjob, in a disabled state' do
+          should contain_cron('run_puppet_agent').with({
+           :name=>"run_puppet_agent",
+           :ensure=>"absent",
+           :command=>"puppet agent -t",
+           :special=>"absent"
+          })
+         end
+        it 'should contain the puppet service, enabled, per default parameters' do
+          should contain_service('puppet').with({
+            :ensure=>true,
+            :enable=>true,
+          }).that_requires('Class[Puppet::Config]')
+        end
+      end
+      context 'when $::puppet::enable_mechanism is cron' do
+        let (:pre_condition){"class{'::puppet': enabled => true, enable_mechanism => 'cron', }"}
+        it'should contain the puppet service, in a disabled state' do
+          should contain_service('puppet').with({
+            :name=>"puppet",
+            :ensure=>false,
+            :enable=>false,
+          }).that_requires('Class[Puppet::Config]')
+        end
+        it 'should enable the cronjob, running puppet twice an hour' do
+          should contain_cron('run_puppet_agent').with({
+            :ensure=>"present",
+            :command=>"puppet agent -t",
+            :special=>"absent",
+            :minute=>["3", 33],
+            :hour=>"*"
+          })
+        end
+        context 'when agent_cron_min has the value of two_times_an_hour' do
+          let (:pre_condition){"class{'::puppet': enabled => true, enable_mechanism => 'cron', agent_cron_min => 'two_times_an_hour'}"}
+          it 'should enable the cronjob, running puppet twice an hour' do
+            should contain_cron('run_puppet_agent').with({
+              :ensure=>"present",
+              :command=>"puppet agent -t",
+              :special=>"absent",
+              :minute=>["3", 33],
+              :hour=>"*"
+            })
+          end
+          it'should contain the puppet service, in a disabled state' do
+            should contain_service('puppet').with({
+              :name=>"puppet",
+              :ensure=>false,
+              :enable=>false,
+            })
+          end
+        end
+        context 'when agent_cron_min has the value of four_times_an_hour' do
+          let (:pre_condition){"class{'::puppet': enabled => true, enable_mechanism => 'cron', agent_cron_min => 'four_times_an_hour'}"}
+          it 'should enable the cronjob, running puppet four times an hour' do
+            should contain_cron('run_puppet_agent').with({
+              :ensure=>"present",
+              :command=>"puppet agent -t",
+              :special=>"absent",
+              :minute=>["3", 18, 33, 48],
+              :hour=>"*"
+            })
+          end
+          it'should contain the puppet service, in a disabled state' do
+            should contain_service('puppet').with({
+              :name=>"puppet",
+              :ensure=>false,
+              :enable=>false,
+            })
+          end
+        end
+        context 'when agent_cron_min has the value of \'30\'' do
+          let (:pre_condition){"class{'::puppet': enabled => true, enable_mechanism => 'cron', agent_cron_min => '30'}"}
+          it 'should enable the cronjob, running puppet twice an hour' do
+            should contain_cron('run_puppet_agent').with({
+              :ensure=>"present",
+              :command=>"puppet agent -t",
+              :special=>"absent",
+              :minute=>"30",
+              :hour=>"*"
+            })
+          end
+          it'should contain the puppet service, in a disabled state' do
+            should contain_service('puppet').with({
+              :name=>"puppet",
+              :ensure=>false,
+              :enable=>false,
+            })
+          end
+        end
+        context 'when agent_cron_hour has the value of \'20\'' do
+          let (:pre_condition){"class{'::puppet': enabled => true, enable_mechanism => 'cron', agent_cron_hour => '20'}"}
+          it 'should enable the cronjob, running puppet twice an hour' do
+            should contain_cron('run_puppet_agent').with({
+              :ensure=>"present",
+              :command=>"puppet agent -t",
+              :special=>"absent",
+              :minute=>["3", 33],
+              :hour=>"20"
+            })
+          end
+          it'should contain the puppet service, in a disabled state' do
+            should contain_service('puppet').with({
+              :name=>"puppet",
+              :ensure=>false,
+              :enable=>false,
+            })
+          end
+        end
+      end
+    end
+    context 'when $::puppet::enabled is false' do
+      let (:pre_condition){"class{'::puppet': enabled => false}"}
+      it'should contain the puppet service, in a disabled state' do
+        should contain_service('puppet').with({
+          :name=>"puppet",
+          :ensure=>false,
+          :enable=>false,
+        })
+      end
+      it 'should contain the puppet agent cronjob, in a disabled state' do
+        should contain_cron('run_puppet_agent').with({
+         :name=>"run_puppet_agent",
+         :ensure=>"absent",
+         :command=>"puppet agent -t",
+         :special=>"absent"
+        })
+      end
+    end
   end
 end

--- a/spec/classes/puppet_spec.rb
+++ b/spec/classes/puppet_spec.rb
@@ -5,7 +5,7 @@ require 'pry'
 describe 'puppet', :type => :class do
 
   context 'input validation' do
-    let (:facts){{'lsbdistid' => 'Debian', 'lsbdistid' => 'Debian', 'lsbdistcodename' => 'trusty'}}
+    let (:facts){{'lsbdistid' => 'Debian', 'lsbdistcodename' => 'trusty'}}
 
 #    ['path'].each do |paths|
 #      context "when the #{paths} parameter is not an absolute path" do
@@ -43,6 +43,16 @@ describe 'puppet', :type => :class do
 #      end
 #    end#hashes
 
+    ['enable_mechanism'].each do |regex|
+      context "when #{regex} has an unsupported value" do
+        let (:params) {{regex => 'BOGON'}}
+        it 'should fail' do
+          expect { subject }.to raise_error(Puppet::Error, /"BOGON" does not match/)
+        end
+      end
+    end#regexes
+
+
     ['environment','facter_version','hiera_version','puppet_server','puppet_version','runinterval',].each do |strings|
       context "when the #{strings} parameter is not a string" do
         let (:params) {{strings => false }}
@@ -74,8 +84,8 @@ describe 'puppet', :type => :class do
          'structured_facts'=>false,
         }).that_notifies('class[Puppet::Agent]')
       end
-      it 'should instantiate the puppet::agent class with the default params' do
-        should contain_class('puppet::agent').with({'ensure' => 'running', 'enable' => true})
+      it 'should instantiate the puppet::agent class' do
+        should contain_class('puppet::agent')
       end
       it 'should instantiate the puppet::facts class' do
         should contain_class('puppet::facts')
@@ -89,8 +99,8 @@ describe 'puppet', :type => :class do
     end#devel_repo
     context 'when the enabled param is false' do
       let (:params){{'enabled' => false}}
-      it 'should instantiate the puppet::agent class apropriately' do
-        should contain_class('puppet::agent').with({'ensure' => 'stopped', 'enable' => false})
+      it 'should instantiate the puppet::agent class' do
+        should contain_class('puppet::agent')
       end
     end#enabled
     context 'when the environment param is set' do


### PR DESCRIPTION
- Add the ability to use the puppet service, or run puppet as a cronjob on a regular schedule. This fixes issue #2.
- Since the moving parts had to change anyways, I removed the extra params for the service enamblemint described in issue #4
- Some minor README.md fixups.
