### PR TITLE
Issue 51

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,7 +11,7 @@ fixtures:
       ref:  "4.6.0"
     apt:
       repo: "puppetlabs/apt"
-      ref:  "1.8.0"
+      ref:  "2.1.0"
     inifile:
       repo: "puppetlabs/inifile"
       ref:  "1.2.0"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,10 +17,10 @@ fixtures:
       ref:  "1.2.0"
     postgresql:
       repo: "puppetlabs/postgresql"
-      ref:  "4.3.0"
+      ref:  "4.6.0"
     puppetdb:
       repo: "puppetlabs/puppetdb"
-      ref:  "4.2.1"
+      ref:  "5.0.0"
     firewall:
       repo: "puppetlabs/firewall"
       ref:  "1.5.0"

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -39,6 +39,9 @@ class puppet::defaults {
     }
     $facterbasepath            = '/opt/puppetlabs/facter'
     $reports_dir               = '/opt/puppetlabs/server/data/reports'
+    $terminus_package          = 'puppetdb-termini'
+    $puppetdb_etcdir           = '/etc/puppetlabs/puppetdb'
+    $puppetdb_test_url         = '/pdb/meta/v1/version'
   } else {
     $server_type               = 'passenger'
     $confdir                   = '/etc/puppet'
@@ -51,7 +54,12 @@ class puppet::defaults {
     }
     $facterbasepath            = '/etc/facter'
     $reports_dir               = '/var/lib/puppet/reports'
+    $terminus_package          = 'puppetdb-terminus'
+    $puppetdb_etcdir           = '/etc/puppetdb'
+    $puppetdb_test_url         = '/v3/version'
   }
+  $puppetdb_confdir          = "${puppetdb_etcdir}/conf.d"
+  $puppetdb_ssl_dir          = "${puppetdb_etcdir}/ssl"
   $autosign_file             = "${confdir}/autosign.conf"
   $environmentpath           = "${codedir}/environments"
   $hiera_eyaml_key_directory = "${codedir}/hiera_eyaml_keys"

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -22,7 +22,7 @@ class puppet::repo::apt {
         ensure     => 'present',
         location   => 'http://apt.puppetlabs.com',
         repos      => $::puppet::collection,
-        key        => '4BD6EC30',#'47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+        key        => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
         key_server => 'pgp.mit.edu',
       }
     } else {
@@ -30,14 +30,14 @@ class puppet::repo::apt {
         ensure     => $source_ensure,
         location   => 'http://apt.puppetlabs.com',
         repos      => 'main dependencies',
-        key        => '4BD6EC30',#'47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+        key        => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
         key_server => 'pgp.mit.edu',
       }
       apt::source { 'puppetlabs_devel':
         ensure     => $devel_ensure,
         location   => 'http://apt.puppetlabs.com',
         repos      => 'devel',
-        key        => '4BD6EC30',#'47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+        key        => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
         key_server => 'pgp.mit.edu',
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=1.8.0 <2.0.0"
+      "version_requirement": ">=1.8.0 <3.0.0"
     },
     {
       "name": "puppetlabs/inifile",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "abstractit-puppet",
-  "version": "2.1.2",
+  "version": "2.2.0-beta",
   "author": "Abstract IT",
   "license": "Apache-2.0",
   "summary": "Manage Puppet agent, master, modules and hiera with Puppet",
@@ -65,7 +65,7 @@
     },
     {
       "name": "puppetlabs/puppetdb",
-      "version_requirement": ">=4.2.1 <5.0.0"
+      "version_requirement": ">=5.0.0 <6.0.0"
     },
     {
       "name": "zack/r10k",

--- a/spec/classes/puppet_profile_agent_spec.rb
+++ b/spec/classes/puppet_profile_agent_spec.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+require 'pry'
+
+describe 'puppet::profile::agent', :type => :class do
+  context 'input validation' do
+
+    # ['path'].each do |paths|
+    #   context "when the #{paths} parameter is not an absolute path" do
+    #     let(:params) {{ paths => 'foo' }}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #       expect { subject }.to raise_error(Puppet::Error)#, /"foo" is not an absolute path/)
+    #     end
+    #   end
+    # end#absolute path
+
+    # ['array'].each do |arrays|
+    #   context "when the #{arrays} parameter is not an array" do
+    #     let(:params) {{ arrays => 'this is a string'}}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #        expect { subject }.to raise_error(Puppet::Error)#, /is not an Array./)
+    #     end
+    #   end
+    # end#arrays
+
+    # ['bool'].each do |bools|
+    #   context "when the #{bools} parameter is not an boolean" do
+    #     let(:params) {{bools => "BOGON"}}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #       expect { subject }.to raise_error(Puppet::Error)#, /"BOGON" is not a boolean.  It looks to be a String/)
+    #     end
+    #   end
+    # end#bools
+
+    # ['foo_hash'].each do |hashes|
+    #   context "when the #{hashes} parameter is not an hash" do
+    #     let(:params) {{ hashes => 'this is a string'}}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #        expect { subject }.to raise_error(Puppet::Error)#, /is not a Hash./)
+    #     end
+    #   end
+    # end#hashes
+
+    # ['string'].each do |strings|
+    #   context "when the #{strings} parameter is not a string" do
+    #     let(:params) {{strings => false }}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #       expect { subject }.to raise_error(Puppet::Error)#, /false is not a string./)
+    #     end
+    #   end
+    # end#strings
+
+  end#input validation
+
+  on_supported_os({
+      :hardwaremodels => ['x86_64'],
+      :supported_os   => [
+        {
+          "operatingsystem" => "Ubuntu",
+          "operatingsystemrelease" => [
+            "14.04"
+          ]
+        },
+        {
+          "operatingsystem" => "CentOS",
+          "operatingsystemrelease" => [
+            "7"
+          ]
+        }
+      ],
+    }).each do |os, facts|
+    context "When on an #{os} system" do
+      let(:facts) do
+        facts.merge({
+          :concat_basedir => '/tmp',
+          :puppetversion => Puppet.version
+        })
+      end
+      it { is_expected.to compile.with_all_deps }
+      if Puppet.version.to_f >= 4.0
+        confdir        = '/etc/puppetlabs/puppet'
+        codedir        = '/etc/puppetlabs/code'
+      else
+        confdir        = '/etc/puppet'
+        codedir        = '/etc/puppet'
+      end
+      context 'when fed no parameters' do
+      end#no params
+    end
+  end
+end

--- a/spec/classes/puppet_profile_master_spec.rb
+++ b/spec/classes/puppet_profile_master_spec.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+require 'pry'
+
+describe 'puppet::profile::master', :type => :class do
+  context 'input validation' do
+
+    # ['path'].each do |paths|
+    #   context "when the #{paths} parameter is not an absolute path" do
+    #     let(:params) {{ paths => 'foo' }}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #       expect { subject }.to raise_error(Puppet::Error)#, /"foo" is not an absolute path/)
+    #     end
+    #   end
+    # end#absolute path
+
+    # ['array'].each do |arrays|
+    #   context "when the #{arrays} parameter is not an array" do
+    #     let(:params) {{ arrays => 'this is a string'}}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #        expect { subject }.to raise_error(Puppet::Error)#, /is not an Array./)
+    #     end
+    #   end
+    # end#arrays
+
+    # ['bool'].each do |bools|
+    #   context "when the #{bools} parameter is not an boolean" do
+    #     let(:params) {{bools => "BOGON"}}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #       expect { subject }.to raise_error(Puppet::Error)#, /"BOGON" is not a boolean.  It looks to be a String/)
+    #     end
+    #   end
+    # end#bools
+
+    # ['foo_hash'].each do |hashes|
+    #   context "when the #{hashes} parameter is not an hash" do
+    #     let(:params) {{ hashes => 'this is a string'}}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #        expect { subject }.to raise_error(Puppet::Error)#, /is not a Hash./)
+    #     end
+    #   end
+    # end#hashes
+
+    # ['string'].each do |strings|
+    #   context "when the #{strings} parameter is not a string" do
+    #     let(:params) {{strings => false }}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #       expect { subject }.to raise_error(Puppet::Error)#, /false is not a string./)
+    #     end
+    #   end
+    # end#strings
+
+  end#input validation
+
+  on_supported_os({
+      :hardwaremodels => ['x86_64'],
+      :supported_os   => [
+        {
+          "operatingsystem" => "Ubuntu",
+          "operatingsystemrelease" => [
+            "14.04"
+          ]
+        },
+        {
+          "operatingsystem" => "CentOS",
+          "operatingsystemrelease" => [
+            "7"
+          ]
+        }
+      ],
+    }).each do |os, facts|
+    context "When on an #{os} system" do
+      let(:facts) do
+        facts.merge({
+          :concat_basedir => '/tmp',
+          :puppetversion => Puppet.version
+        })
+      end
+      it { is_expected.to compile.with_all_deps }
+      if Puppet.version.to_f >= 4.0
+        confdir        = '/etc/puppetlabs/puppet'
+        codedir        = '/etc/puppetlabs/code'
+      else
+        confdir        = '/etc/puppet'
+        codedir        = '/etc/puppet'
+      end
+      context 'when fed no parameters' do
+      end#no params
+    end
+  end
+end

--- a/spec/classes/puppet_profile_puppetdb_spec.rb
+++ b/spec/classes/puppet_profile_puppetdb_spec.rb
@@ -1,0 +1,154 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+require 'pry'
+
+describe 'puppet::profile::puppetdb', :type => :class do
+  context 'input validation' do
+
+    # ['foo'].each do |paths|
+    #   context "when the #{paths} parameter is not an absolute path" do
+    #     let(:params) {{ paths => 'foo' }}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #       expect { subject }.to raise_error(Puppet::Error)#, /"foo" is not an absolute path/)
+    #     end
+    #   end
+    # end#absolute path
+
+    # ['array'].each do |arrays|
+    #   context "when the #{arrays} parameter is not an array" do
+    #     let(:params) {{ arrays => 'this is a string'}}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #        expect { subject }.to raise_error(Puppet::Error)#, /is not an Array./)
+    #     end
+    #   end
+    # end#arrays
+
+    ['reports','use_ssl'].each do |bools|
+      context "when the #{bools} parameter is not an boolean" do
+        let(:params) {{bools => "BOGON"}}
+        it 'should fail' do
+          skip 'This does not work as is'
+          expect { subject }.to raise_error(Puppet::Error)#, /"BOGON" is not a boolean.  It looks to be a String/)
+        end
+      end
+    end#bools
+
+    # ['foo_hash'].each do |hashes|
+    #   context "when the #{hashes} parameter is not an hash" do
+    #     let(:params) {{ hashes => 'this is a string'}}
+    #     it 'should fail' do
+    #       skip 'This does not work as is'
+    #        expect { subject }.to raise_error(Puppet::Error)#, /is not a Hash./)
+    #     end
+    #   end
+    # end#hashes
+
+    ['puppetdb_version','node_purge_ttl','node_ttl','puppetdb_listen_address','puppetdb_server','puppetdb_ssl_listen_address','report_ttl','listen_port','ssl_listen_port','puppet_server_type'].each do |strings|
+      context "when the #{strings} parameter is not a string" do
+        let(:params) {{strings => false }}
+        it 'should fail' do
+          skip 'This does not work as is'
+          expect { subject }.to raise_error(Puppet::Error)#, /false is not a string./)
+        end
+      end
+    end#strings
+
+  end#input validation
+
+  on_supported_os({
+      :hardwaremodels => ['x86_64'],
+      :supported_os   => [
+        {
+          "operatingsystem" => "Ubuntu",
+          "operatingsystemrelease" => [
+            "14.04"
+          ]
+        },
+        {
+          "operatingsystem" => "CentOS",
+          "operatingsystemrelease" => [
+            "7"
+          ]
+        }
+      ],
+    }).each do |os, facts|
+    context "When on an #{os} system" do
+      let(:facts) do
+        facts.merge({
+          :concat_basedir => '/tmp',
+          :fqdn           => 'constructorfleet.vogon.gal',
+          :domain         => 'vogon.gal',
+          :puppetversion  => Puppet.version
+        })
+      end
+      it { is_expected.to compile.with_all_deps }
+      if Puppet.version.to_f >= 4.0
+        confdir           = '/etc/puppetlabs/puppet'
+        codedir           = '/etc/puppetlabs/code'
+        terminus_package  = 'puppetdb-termini'
+        puppetdb_confdir  = '/etc/puppetlabs/puppetdb/conf.d'
+        puppetdb_ssldir   = '/etc/puppetlabs/puppetdb/ssl'
+        puppetdb_test_url = '/pdb/meta/v1/version'
+      else
+        confdir          = '/etc/puppet'
+        codedir          = '/etc/puppet'
+        terminus_package = 'puppetdb-terminus'
+        puppetdb_confdir  = '/etc/puppetdb/conf.d'
+        puppetdb_ssldir   = '/etc/puppetdb/ssl'
+        puppetdb_test_url = '/v3/version'
+      end
+
+      context 'when fed no parameters' do
+        # it 'should include class ::postgresql::server::contrib' do
+        #   should include_class('::postgresql::server::contrib')
+        # end
+        # it 'should setup pg_trgm extension' do
+        #   should contain_postgresql__server__extension('pg_trgm').with({
+        #     :database => 'puppetdb'
+        #   })
+        # end
+        it 'should contain class ::puppetdb::globals' do
+          should contain_class('puppetdb::globals').with({
+            :version => 'installed'
+          })
+        end
+        it 'should contain class ::puppetdb' do
+          should contain_class('puppetdb').with({
+            :listen_port        => '8080',
+            :ssl_listen_port    => '8081',
+            :disable_ssl        => false,
+            :listen_address     => '127.0.0.1',
+            :ssl_listen_address => '0.0.0.0',
+            :node_ttl           => '0s',
+            :node_purge_ttl     => '0s',
+            :report_ttl         => '14d',
+            :confdir            => "#{puppetdb_confdir}",
+            :ssl_dir            => "#{puppetdb_ssldir}",
+          })
+        end
+        it 'should contain class puppetdb::master::config' do
+          should contain_class('puppetdb::master::config').with({
+            :manage_config           => false,
+            :test_url                => "#{puppetdb_test_url}",
+            :puppetdb_port           => '8081',
+            :puppetdb_server         => 'puppet.vogon.gal',
+            :puppet_service_name     => 'httpd',
+            :enable_reports          => true,
+            :manage_report_processor => true,
+            :restart_puppet          => true,
+          })
+        end
+        it 'should contain class puppetdb::master::puppetdb_conf' do
+          should contain_class('puppetdb::master::puppetdb_conf').with({
+            :port            => '8081',
+            :puppet_confdir  => "#{confdir}",
+            :legacy_terminus => "#{terminus_package}",
+          })
+        end
+      end#no params
+
+    end
+  end
+end

--- a/spec/classes/puppet_repo_apt_spec.rb
+++ b/spec/classes/puppet_repo_apt_spec.rb
@@ -38,7 +38,7 @@ describe 'puppet::repo::apt', :type => :class do
            :ensure=>"present",
            :location=>"http://apt.puppetlabs.com",
            :repos=>"main dependencies",
-           :key=>"4BD6EC30",
+           :key=>"47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30",
            :key_server=>"pgp.mit.edu",
            :comment=>"puppetlabs",
           })
@@ -49,7 +49,7 @@ describe 'puppet::repo::apt', :type => :class do
             :ensure=>"absent",
             :location=>"http://apt.puppetlabs.com",
             :repos=>"devel",
-            :key=>"4BD6EC30",
+            :key=>"47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30",
             :key_server=>"pgp.mit.edu",
             :comment=>"puppetlabs_devel",
           })
@@ -64,7 +64,7 @@ describe 'puppet::repo::apt', :type => :class do
             :ensure=>"present",
             :location=>"http://apt.puppetlabs.com",
             :repos=>"BOGON",
-            :key=>"4BD6EC30",
+            :key=>"47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30",
             :key_server=>"pgp.mit.edu",
             })
           should_not contain_apt__source('puppetlabs')
@@ -88,7 +88,7 @@ describe 'puppet::repo::apt', :type => :class do
               :ensure=>"absent",
               :location=>"http://apt.puppetlabs.com",
               :repos=>"devel",
-              :key=>"4BD6EC30",
+              :key=>"47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30",
               :key_server=>"pgp.mit.edu",
               :comment=>"puppetlabs_devel",
             })
@@ -103,7 +103,7 @@ describe 'puppet::repo::apt', :type => :class do
               :ensure=>"present",
               :location=>"http://apt.puppetlabs.com",
               :repos=>"devel",
-              :key=>"4BD6EC30",
+              :key=>"47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30",
               :key_server=>"pgp.mit.edu",
               :comment=>"puppetlabs_devel",
             })


### PR DESCRIPTION
switch to puppetlabs-puppetdb 5.0.0 and puppetlabs-postgresql 4.6.0
Switch to full key ids
Apt 2.1.0+ supports for old parameters from apt 1.8.0
So it will not work with apt 2.0.0

Fixes #51