### PR TITLE
puppet::profile::puppetboard: use parameter instead of hardcoding manage_virtualenv.

### DIFF
--- a/manifests/profile/puppetboard.pp
+++ b/manifests/profile/puppetboard.pp
@@ -46,7 +46,7 @@ class puppet::profile::puppetboard (
     git_source        => $git_source,
     puppetdb_port     => $puppetdb_port,
     puppetdb_host     => $puppetdb_host,
-    manage_virtualenv => true,
+    manage_virtualenv => $manage_virtualenv,
   }
 
   class { '::puppetboard::apache::vhost':


### PR DESCRIPTION
Pass manage_virtualenv parameter to puppetboard.