### PR TITLE
puppet::profile::puppetdb: validate_integer use the second argument as a maximum.

### DIFF
--- a/manifests/profile/puppetdb.pp
+++ b/manifests/profile/puppetdb.pp
@@ -54,8 +54,10 @@ class puppet::profile::puppetdb (
     $report_ttl,
   )
   validate_integer(
-    $listen_port,
-    $ssl_listen_port
+    [
+      $listen_port,
+      $ssl_listen_port,
+    ]
   )
 
   # add deprecation warnings


### PR DESCRIPTION
 validate_integer use the second argument as a maximum, but the first one can be an array