### PR TITLE
Point to GPG key on Puppetlabs server

### DIFF
--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -22,7 +22,7 @@ class puppet::repo::yum {
         baseurl  => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/${::puppet::collection}/${::architecture}",
         enabled  => '1',
         gpgcheck => '1',
-        gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+        gpgkey   => 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
       }
     } else {
 
@@ -31,14 +31,14 @@ class puppet::repo::yum {
         baseurl  => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/products/${::architecture}",
         enabled  => '1',
         gpgcheck => '1',
-        gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+        gpgkey   => 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
       }
       yumrepo { 'puppetlabs-products-source':
         descr    => "Puppet Labs Products EL ${::operatingsystemmajrelease} - ${::architecture} - Source",
         baseurl  => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/products/SRPMS",
         enabled  => $source_enable,
         gpgcheck => '1',
-        gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+        gpgkey   => 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
       }
 
       yumrepo { 'puppetlabs-deps':
@@ -46,14 +46,14 @@ class puppet::repo::yum {
         baseurl  => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/dependencies/${::architecture}",
         enabled  => '1',
         gpgcheck => '1',
-        gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+        gpgkey   => 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
       }
       yumrepo { 'puppetlabs-deps-source':
         descr          => "Puppet Labs Dependencies EL ${::operatingsystemmajrelease} - ${::architecture} - Source",
         baseurl        => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/dependencies/SRPMS",
         enabled        => $source_enable,
         gpgcheck       => '1',
-        gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+        gpgkey         => 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
         failovermethod => 'priority'
       }
 
@@ -62,14 +62,14 @@ class puppet::repo::yum {
         baseurl  => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/devel/${::architecture}",
         enabled  => $devel_enabled,
         gpgcheck => '1',
-        gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+        gpgkey   => 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
       }
       yumrepo { 'puppetlabs-devel-source':
         descr    => "Puppet Labs Devel EL ${::operatingsystemmajrelease} - ${::architecture} - Source",
         baseurl  => "http://yum.puppetlabs.com/el/${::operatingsystemmajrelease}/devel/SRPMS",
         enabled  => $source_enable,
         gpgcheck => '1',
-        gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+        gpgkey   => 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
       }
     }
 


### PR DESCRIPTION
Point to GPG key on Puppetlabs server since this module does not deploy the key to `/etc/pki/rpm-gpg`. This caused problems for me on a clean install and I had to install the key manually.

Alternatively, you could make this module install the key using wget or similar.