### PR TITLE
hiera-eyaml gem provider fix for puppet 4

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,5 +24,8 @@ fixtures:
     firewall:
       repo: "puppetlabs/firewall"
       ref:  "1.5.0"
+    puppetserver_gem:
+      repo: "puppetlabs/puppetserver_gem"
+      ref:  "0.1.0"
   symlinks:
     puppet: "#{source_dir}"

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -42,6 +42,7 @@ class puppet::defaults {
     $terminus_package          = 'puppetdb-termini'
     $puppetdb_etcdir           = '/etc/puppetlabs/puppetdb'
     $puppetdb_test_url         = '/pdb/meta/v1/version'
+    $gem_provider              = 'puppetserver_gem'
   } else {
     $server_type               = 'passenger'
     $confdir                   = '/etc/puppet'
@@ -57,6 +58,7 @@ class puppet::defaults {
     $terminus_package          = 'puppetdb-terminus'
     $puppetdb_etcdir           = '/etc/puppetdb'
     $puppetdb_test_url         = '/v3/version'
+    $gem_provider              = 'gem'
   }
   $puppetdb_confdir          = "${puppetdb_etcdir}/conf.d"
   $puppetdb_ssl_dir          = "${puppetdb_etcdir}/ssl"

--- a/manifests/master/install.pp
+++ b/manifests/master/install.pp
@@ -12,6 +12,7 @@ class puppet::master::install {
   $puppet_version             = $::puppet::master::puppet_version
   $puppetmaster_pkg           = $::puppet::defaults::puppetmaster_pkg
   $server_version             = $::puppet::master::server_version
+  $gem_provider               = $::puppet::defaults::gem_provider
 
   if ($allinone == true) {
     $server_package  = 'puppetserver'
@@ -39,7 +40,7 @@ class puppet::master::install {
   if $manage_hiera_eyaml_package {
     package { 'hiera-eyaml':
       ensure   => $hiera_eyaml_version,
-      provider => gem
+      provider => $gem_provider
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -74,6 +74,10 @@
     {
       "name": "puppet/puppetboard",
       "version_requirement": ">=2.7.0 <3.0.0"
+    },
+    {
+      "name": "puppetlabs/puppetserver_gem",
+      "version_requirement": ">=0.1.0"
     }
   ]
 }

--- a/spec/classes/puppet_master_install_spec.rb
+++ b/spec/classes/puppet_master_install_spec.rb
@@ -74,11 +74,24 @@ describe 'puppet::master::install', :type => :class do
 
         context 'when ::puppet::master::manage_hiera_eyaml_package is true' do
           let(:pre_condition){"class{'::puppet::master': manage_hiera_eyaml_package=>true }"}
-          it 'should install the hiera-eyaml package' do
-            should contain_package('hiera-eyaml').with({
-              :ensure => 'installed',
-              :provider => 'gem'
-            })
+          if Puppet.version.to_f >= 4.0
+            context 'when puppetversion >= 4' do
+              it 'should install the hiera-eyaml package with the puppetserver_gem provider' do
+                should contain_package('hiera-eyaml').with({
+                  :ensure   => 'installed',
+                  :provider => 'puppetserver_gem'
+                })
+              end
+            end
+          else
+            context 'when puppetversion < 4' do
+              it 'should install the hiera-eyaml package with the gem provider' do
+                should contain_package('hiera-eyaml').with({
+                  :ensure   => 'installed',
+                  :provider => 'gem'
+                })
+              end
+            end
           end
         end#manage_hiera_eyaml_package true
 
@@ -159,11 +172,24 @@ describe 'puppet::master::install', :type => :class do
       context 'when the hiera_eyaml_version param has a non-standard value' do
         let(:pre_condition) {"class{'::puppet::master': manage_hiera_eyaml_package=>true }"}
         let(:pre_condition) {"class{'::puppet::master': hiera_eyaml_version=>'BOGON' }"}
-        it 'should install the specified version of the hiera-eyaml package' do
-          should contain_package('hiera-eyaml').with({
-            'ensure' => "BOGON",
-            'provider'=> "gem"
-          })
+        if Puppet.version.to_f >= 4.0
+          context 'when puppetversion >= 4' do
+            it 'should install the specified version of the hiera-eyaml package with the puppetserver_gem provider' do
+              should contain_package('hiera-eyaml').with({
+                :ensure   => 'BOGON',
+                :provider => 'puppetserver_gem'
+              })
+            end
+          end
+        else
+          context 'when puppetversion < 4' do
+            it 'should install the specified version of the hiera-eyaml package with the gem provider' do
+              should contain_package('hiera-eyaml').with({
+                :ensure   => 'BOGON',
+                :provider => 'gem'
+              })
+            end
+          end
         end
       end # hiera_eyaml_version defined
 


### PR DESCRIPTION
Hi. Fix is to resolve ‘Provider gem is not functional on this host’ when using puppet 4. I hit this issue when trying to install hiera-eyaml against puppet 4.

Due to the changes with this version I believe that rubygems is no longer installed as part of the puppet install.

With puppet 4 it has a version of the gem binary under:
/opt/puppetlabs/puppet/bin/gem

and the puppetserver_gem uses this:
https://forge.puppetlabs.com/puppetlabs/puppetserver_gem

further reading:
https://docs.puppetlabs.com/puppetserver/latest/gems.html#installing-and-removing-gems

I have also updated/added some tests for this fix.