### PR TITLE
Fix for puppetmaster deploy when puppetdb is on a remote node

### DIFF
--- a/manifests/profile/master.pp
+++ b/manifests/profile/master.pp
@@ -227,7 +227,6 @@ class puppet::profile::master (
       enable_reports          => $reports,
       manage_report_processor => $reports,
       restart_puppet          => $restart_puppet,
-      require                 => Class['::puppetdb'],
     }
   }
 


### PR DESCRIPTION
This is to address the issue here https://github.com/abstractitptyltd/abstractit-puppet/issues/80