### PR TITLE
Update metadata.json to allow use of zack-r10k version 3.2.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "zack/r10k",
-      "version_requirement": ">=2.7.0 <3.2.0"
+      "version_requirement": ">=2.7.0 <=3.2.0"
     },
     {
       "name": "puppet/puppetboard",

--- a/metadata.json
+++ b/metadata.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "zack/r10k",
-      "version_requirement": ">=2.7.0 <3.0.0"
+      "version_requirement": ">=2.7.0 <4.0.0"
     },
     {
       "name": "puppet/puppetboard",

--- a/metadata.json
+++ b/metadata.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "zack/r10k",
-      "version_requirement": ">=2.7.0 <4.0.0"
+      "version_requirement": ">=2.7.0 <3.2.0"
     },
     {
       "name": "puppet/puppetboard",


### PR DESCRIPTION
zack-r10k is at version 3.2.0 as of Dec/2015. I'd like to use the newer zack-r10k and abstractit-puppet if possible.