### PR TITLE
Support for dns_alt_names

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,10 @@ The `puppet::config` class is responsible for altering the configuration of `$co
 
   The version of the deep_merge package to install.
 
+  * **dns_alt_names**: (*array* Default: `undef`)
+
+  An array of alternative DNS names to use for the local host.
+
   * **env_owner**: (*string* Default: `puppet`)
 
   The user which should own hieradata and r10k repos

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -18,6 +18,8 @@
 #   The base directory path to have environments checked out into.
 # @param deep_merge_version ([String] Default: 'installed')
 #   The version of the deep_merge package to install.
+# @param dns_alt_names ([Array] Default: empty)
+#   An array of alternative DNS names to use for the local host
 # @param env_owner [String] Default: 'puppet'
 #   The user which should own hieradata and r10k repos
 # @param environmentpath (*absolute path* Default Puppet 4: ${codedir}/modules:${confdir}/modules Default Puppet 3: ${confdir}/modules:/usr/share/puppet/modules)
@@ -90,6 +92,7 @@ class puppet::master (
   $autosign_method                    = 'file',
   $basemodulepath                     = $::puppet::defaults::basemodulepath,
   $deep_merge_version                 = 'installed',
+  $dns_alt_names                      = [],
   $env_owner                          = 'puppet',
   $environmentpath                    = $::puppet::defaults::environmentpath,
   $environment_timeout                = '0',
@@ -135,6 +138,7 @@ class puppet::master (
     $hieradata_path,
   )
   validate_array(
+    $dns_alt_names,
     $hiera_hierarchy,
   )
 

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -7,6 +7,7 @@ class puppet::master::config {
   $codedir              = $::puppet::defaults::codedir
   $reports_dir          = $::puppet::defaults::reports_dir
   $ca_server            = $::puppet::ca_server
+  $dns_alt_names        = $::puppet::master::dns_alt_names
   $autosign_method      = $::puppet::master::autosign_method
   $autosign_file        = $::puppet::master::autosign_file
   $autosign_domains     = $::puppet::master::autosign_domains
@@ -126,6 +127,30 @@ class puppet::master::config {
       section => 'master',
       setting => 'parser',
       value   => 'future'
+    }
+  }
+
+  if (! empty($dns_alt_names) ) {
+
+    # need it as a string
+    $_dns_alt_names = join($dns_alt_names, ',')
+
+    # enable dns_alt_names
+    ini_setting { 'master dns_alt_names':
+      ensure  => present,
+      path    => "${confdir}/puppet.conf",
+      section => 'main',
+      setting => 'dns_alt_names',
+      value   => $_dns_alt_names,
+    }
+  } else {
+    # disable dns_alt_names
+    ini_setting { 'master dns_alt_names':
+      ensure  => absent,
+      path    => "${confdir}/puppet.conf",
+      section => 'main',
+      setting => 'dns_alt_names',
+      value   => $_dns_alt_names,
     }
   }
 

--- a/manifests/profile/master.pp
+++ b/manifests/profile/master.pp
@@ -19,6 +19,8 @@
 #   The base directory path to have environments checked out into.
 # @param deep_merge_version ([String] Default: 'installed')
 #   The version of the deep_merge package to install.
+# @param dns_alt_names ([Array] Default: empty)
+#   An array of alternative DNS names to use for the local host
 # @param env_owner [String] Default: 'puppet'
 #   The user which should own hieradata and r10k repos
 # @param environmentpath (*absolute path* Default Puppet 4: ${codedir}/modules:${confdir}/modules Default Puppet 3: ${confdir}/modules:/usr/share/puppet/modules)
@@ -111,6 +113,7 @@ class puppet::profile::master (
   $autosign_method                    = 'file',
   $basemodulepath                     = undef,
   $deep_merge_version                 = 'installed',
+  $dns_alt_names                      = undef,
   $env_owner                          = 'puppet',
   $environmentpath                    = undef,
   $environment_timeout                = '0',
@@ -159,6 +162,7 @@ class puppet::profile::master (
     autosign_file                      => $autosign_file,
     autosign_method                    => $autosign_method,
     basemodulepath                     => $basemodulepath,
+    dns_alt_names                      => $dns_alt_names,
     deep_merge_version                 => $deep_merge_version,
     env_owner                          => $env_owner,
     environmentpath                    => $environmentpath,

--- a/spec/classes/puppet_master_config_spec.rb
+++ b/spec/classes/puppet_master_config_spec.rb
@@ -189,6 +189,19 @@ describe 'puppet::master::config', :type => :class do
         end
       end## autosign_method file autosign_domains not empty custom autosign_file
 
+      context 'when $::puppet::master::dns_alt_names is not empty' do
+        let(:pre_condition) {"class{'::puppet::master': dns_alt_names => ['bogan1.domain.com','bogan2.domain.com']}"}
+        it 'should add dns_alt_names in $confdir/puppet.conf' do
+          should contain_ini_setting('dns_alt_names').with({
+            'ensure'  => 'present',
+            'path'    => "#{confdir}/puppet.conf",
+            'section' => 'main',
+            'setting' => 'dns_alt_names',
+            'value'   => 'bogan1.domain.com,bogan2.domain.com',
+          })
+        end
+      end## dns_alt_names not empty
+
       context 'when ::puppet::ca_server is set and this is not the ca_server' do
         let(:pre_condition){"class{'::puppet': ca_server => 'bogon.domain.com'}"}
         let(:facts) do

--- a/spec/classes/puppet_master_spec.rb
+++ b/spec/classes/puppet_master_spec.rb
@@ -15,12 +15,12 @@ describe 'puppet::master', :type => :class do
       end
     end#absolute path
 
-    ['hiera_hierarchy'].each do |arrays|
+    ['dns_alt_names','hiera_hierarchy'].each do |arrays|
       context "when the #{arrays} parameter is not an array" do
-        let(:params) {{ arrays => 'this is a string'}}
+        let(:params) {{ arrays => 'this is not an array'}}
         it 'should fail' do
           # skip 'This does not work as is'
-           expect { catalogue }.to raise_error(Puppet::Error)#, /is not an Array./)
+          expect { catalogue }.to raise_error(Puppet::Error)#, /is not an Array./)
         end
       end
     end#arrays


### PR DESCRIPTION
Support for dns_alt_names configuration in puppet master.

Fixes abstractitptyltd/abstractit-puppet#23