### PR TITLE
define relationship between vhost an package puppetmaster-passenger

### DIFF
--- a/manifests/master/passenger.pp
+++ b/manifests/master/passenger.pp
@@ -76,7 +76,8 @@ class puppet::master::passenger {
         'set X-Client-DN %{SSL_CLIENT_S_DN}e',
         'set X-Client-Verify %{SSL_CLIENT_VERIFY}e',
         ],
-      subscribe          => Class['puppet::master::install']
+      subscribe          => Class['puppet::master::install'],
+      require            => Package['puppetmaster-passenger'],
     }
   }
 }

--- a/spec/classes/puppet_master_passenger_spec.rb
+++ b/spec/classes/puppet_master_passenger_spec.rb
@@ -104,7 +104,7 @@ describe 'puppet::master::passenger', :type => :class do
                   :rack_base_uris=>["/"],
                   :directories=>[{"path"=>"/usr/share/puppet/rack/puppetmasterd/", "options"=>"None"}],
                   :request_headers=>["unset X-Forwarded-For", "set X-SSL-Subject %{SSL_CLIENT_S_DN}e", "set X-Client-DN %{SSL_CLIENT_S_DN}e", "set X-Client-Verify %{SSL_CLIENT_VERIFY}e"]
-                }).that_subscribes_to('Class[puppet::master::install]')
+                }).that_subscribes_to('Class[puppet::master::install]').that_requires('Package[puppetmaster-passenger]')
               else
                 should contain_apache__vhost('constructorfleet.vogon.gal').with({
                   :docroot=>"/usr/share/puppet/rack/puppetmasterd/public/",
@@ -126,7 +126,7 @@ describe 'puppet::master::passenger', :type => :class do
                   :rack_base_uris=>["/"],
                   :directories=>[["path","/usr/share/puppet/rack/puppetmasterd/"], ["options","None"]],
                   :request_headers=>["unset X-Forwarded-For", "set X-SSL-Subject %{SSL_CLIENT_S_DN}e", "set X-Client-DN %{SSL_CLIENT_S_DN}e", "set X-Client-Verify %{SSL_CLIENT_VERIFY}e"]
-                }).that_subscribes_to('Class[puppet::master::install]')
+                }).that_subscribes_to('Class[puppet::master::install]').that_requires('Package[puppetmaster-passenger]')
               end
             end#end apache vhost
           end#no params


### PR DESCRIPTION
Without this relationship first puppet run is not able to find docroot
for vhost and doesn't setup a valid puppetmaster with passenger.