### PR TITLE
Support for using a custom puppet agent via cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ The `puppet` class is responsible for validating some of our parameters, and ins
 
   This param accepts any value accepted by the [cron native type](http://docs.puppetlabs.com/references/latest/type.html#cron-attribute-minute), as well as two special options: `two_times_an_hour`, and `four_times_an_hour`. These specials use [fqdn_rand](http://docs.puppetlabs.com/references/latest/function.html#fqdnrand) to generate a random minute array on the selected interval. This should distribute the load more evenly on your puppetmasters.
 
+  * **agent_custom_cron_command**: (*string* Default: `undef`)
+
+    Optional custom puppet agent cron command
+
   * **agent_version**: (*string* Default: `installed`)
 
     Declares the version of the puppet-agent all-in-one package to install.

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -25,6 +25,12 @@ class puppet::agent {
         $cron_enablement    = 'present'
         $service_enablement = false
         $start_enablement   = 'no'
+        if $::puppet::agent_custom_cron_command {
+          $cron_command = $::puppet::agent_custom_cron_command
+        }
+        else {
+          $cron_command = "${bin_dir}/puppet agent --no-daemonize --onetime"
+        }
       }
       default: {
         #noop. should never happen.
@@ -40,7 +46,7 @@ class puppet::agent {
 
   cron {'run_puppet_agent':
     ensure  => $cron_enablement,
-    command => "${bin_dir}/puppet agent --no-daemonize --onetime",
+    command => $cron_command,
     special => 'absent',
     minute  => $::puppet::agent_cron_min_interpolated,
     hour    => $::puppet::agent_cron_hour_interpolated,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,20 +1,22 @@
-# The main puppet class is responsible for validating some of our parameters, 
+# The main puppet class is responsible for validating some of our parameters,
 # and instantiating the puppet::facts, puppet::repo, pupppet::install,
 # puppet::config and puppet::agent classes.
 #
 # @puppet when declaring the puppet class
 #   include puppet
 #
-# @param allinone [Boolean] Default: false 
+# @param allinone [Boolean] Default: false
 #   Whether to use the new collections
-# @param agent_cron_hour [String] Default: '*' 
+# @param agent_cron_hour [String] Default: '*'
 #   The hour to run the agent cron. Valid values are `0-23`
 # @param agent_cron_min [String/Array] Default: 'two_times_an_hour'
 #   This param accepts any value accepted by the [cron native type](http://docs.puppetlabs.com/references/latest/type.html#cron-attribute-minute),
-#   as well as two special options: `two_times_an_hour`, and `four_times_an_hour`. 
+#   as well as two special options: `two_times_an_hour`, and `four_times_an_hour`.
 #   These specials use [fqdn_rand](http://docs.puppetlabs.com/references/latest/function.html#fqdnrand)
-#   to generate a random minute array on the selected interval. 
+#   to generate a random minute array on the selected interval.
 #   This should distribute the load more evenly on your puppetmasters.
+# @param agent_custom_cron_command [String] Default:  undef
+#   Custom puppet agent cron command
 # @param agent_version [String] Default: 'installed'
 #   Declares the version of the puppet-agent all-in-one package to install.
 # @param ca_server [String] Default: undef
@@ -32,7 +34,7 @@
 # @param enable_devel_repo [Boolean] Default: false
 #   This param will replace `devel_repo` in 2.x.
 #   It conveys to puppet::repo::apt whether or not to add the devel apt repo source.
-#   When `devel_repo` is false, `enable_devel_repo` is consulted for enablement. 
+#   When `devel_repo` is false, `enable_devel_repo` is consulted for enablement.
 #   This gives `devel_repo` backwards compatability at the cost of some confusion if you set `devel_repo` to true, and `enable_devel_repo` to false.
 # @param enable_mechanism [String] Default: 'service'
 #   A toggle which permits the option of running puppet as a service, or as a cron job.
@@ -67,17 +69,18 @@
 # @param runinterval [String] Default: '30m'
 #   Sets the runinterval in puppet.conf
 # @param structured_facts [Boolean] Default: false
-#   Sets whether or not to enable [structured_facts](http://docs.puppetlabs.com/facter/2.0/fact_overview.html) 
-#   by setting the [stringify_facts](http://docs.puppetlabs.com/references/3.6.latest/configuration.html#stringifyfacts) 
+#   Sets whether or not to enable [structured_facts](http://docs.puppetlabs.com/facter/2.0/fact_overview.html)
+#   by setting the [stringify_facts](http://docs.puppetlabs.com/references/3.6.latest/configuration.html#stringifyfacts)
 #   variable in puppet.conf.
 #   **It is important to note that this boolean operates in reverse.
-#   ** Setting stringify_facts to **false** is required to **permit** structured facts. 
+#   ** Setting stringify_facts to **false** is required to **permit** structured facts.
 #   This is why this parameter does not directly correlate with the configuration key.
 
 class puppet (
   $allinone                       = false,
   $agent_cron_hour                = '*',
   $agent_cron_min                 = 'two_times_an_hour',
+  $agent_custom_cron_command      = undef,
   $agent_version                  = 'installed',
   $ca_server                      = undef,
   $cfacter                        = false,

--- a/manifests/profile/agent.pp
+++ b/manifests/profile/agent.pp
@@ -3,16 +3,18 @@
 # @puppet::profile::agent when declaring the puppet::profile::agent class
 #   include puppet::profile::agent
 #
-# @param allinone [Boolean] Default: false 
+# @param allinone [Boolean] Default: false
 #   Whether to use the new collections
-# @param agent_cron_hour [String] Default: '*' 
+# @param agent_cron_hour [String] Default: '*'
 #   The hour to run the agent cron. Valid values are `0-23`
 # @param agent_cron_min [String/Array] Default: 'two_times_an_hour'
 #   This param accepts any value accepted by the [cron native type](http://docs.puppetlabs.com/references/latest/type.html#cron-attribute-minute),
-#   as well as two special options: `two_times_an_hour`, and `four_times_an_hour`. 
+#   as well as two special options: `two_times_an_hour`, and `four_times_an_hour`.
 #   These specials use [fqdn_rand](http://docs.puppetlabs.com/references/latest/function.html#fqdnrand)
-#   to generate a random minute array on the selected interval. 
+#   to generate a random minute array on the selected interval.
 #   This should distribute the load more evenly on your puppetmasters.
+# @param agent_custom_cron_command [String] Default:  undef
+#   Custom puppet agent cron command
 # @param ca_server [String] Default: undef
 #   Server to use as the CA server for all agents.
 # @param agent_version [String] Default: 'installed'
@@ -28,7 +30,7 @@
 # @param enable_devel_repo [Boolean] Default: false
 #   This param will replace `devel_repo` in 2.x.
 #   It conveys to puppet::repo::apt whether or not to add the devel apt repo source.
-#   When `devel_repo` is false, `enable_devel_repo` is consulted for enablement. 
+#   When `devel_repo` is false, `enable_devel_repo` is consulted for enablement.
 #   This gives `devel_repo` backwards compatability at the cost of some confusion if you set `devel_repo` to true, and `enable_devel_repo` to false.
 # @param enable_mechanism [String] Default: 'service'
 #   A toggle which permits the option of running puppet as a service, or as a cron job.
@@ -63,11 +65,11 @@
 # @param runinterval [String] Default: '30m'
 #   Sets the runinterval in puppet.conf
 # @param structured_facts [Boolean] Default: false
-#   Sets whether or not to enable [structured_facts](http://docs.puppetlabs.com/facter/2.0/fact_overview.html) 
-#   by setting the [stringify_facts](http://docs.puppetlabs.com/references/3.6.latest/configuration.html#stringifyfacts) 
+#   Sets whether or not to enable [structured_facts](http://docs.puppetlabs.com/facter/2.0/fact_overview.html)
+#   by setting the [stringify_facts](http://docs.puppetlabs.com/references/3.6.latest/configuration.html#stringifyfacts)
 #   variable in puppet.conf.
 #   **It is important to note that this boolean operates in reverse.
-#   ** Setting stringify_facts to **false** is required to **permit** structured facts. 
+#   ** Setting stringify_facts to **false** is required to **permit** structured facts.
 #   This is why this parameter does not directly correlate with the configuration key.
 
 
@@ -75,6 +77,7 @@ class puppet::profile::agent (
   $allinone                       = false,
   $agent_cron_hour                = '*',
   $agent_cron_min                 = 'two_times_an_hour',
+  $agent_custom_cron_command      = undef,
   $agent_version                  = 'installed',
   $ca_server                      = undef,
   $cfacter                        = false,
@@ -103,6 +106,7 @@ class puppet::profile::agent (
     allinone                       => $allinone,
     agent_cron_hour                => $agent_cron_hour,
     agent_cron_min                 => $agent_cron_min,
+    agent_custom_cron_command      => $agent_custom_cron_command,
     agent_version                  => $agent_version,
     ca_server                      => $ca_server,
     cfacter                        => $cfacter,


### PR DESCRIPTION
This adds support for a custom puppet agent command via cron.

Fixes abstractitptyltd/abstractit-puppet#102