### PR TITLE
Add support for splay and splaylimit parameters in puppet.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,13 @@ The `puppet` class is responsible for validating some of our parameters, and ins
 
     Sets the runinterval in `puppet.conf`
 
+  * **splay**: (*bool* Default `false`)
+
+    Sets the splay parameter in puppet.conf
+  * **splaylimit**: (*string* Default: undef)
+
+    Sets the splaylimit parameter in puppet.conf
+
   * **structured_facts**: (*bool* Default: `false`)
 
     Sets whether or not to enable [structured_facts](http://docs.puppetlabs.com/facter/2.0/fact_overview.html) by setting the [stringify_facts](http://docs.puppetlabs.com/references/3.6.latest/configuration.html#stringifyfacts) variable in puppet.conf.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,8 @@ class puppet::config {
   $puppet_server                  = $::puppet::puppet_server
   $reports                        = $::puppet::reports
   $runinterval                    = $::puppet::runinterval
+  $splay                          = $::puppet::splay
+  $splaylimit                     = $::puppet::splaylimit
   $structured_facts               = $::puppet::structured_facts
   $manage_etc_facter              = $::puppet::manage_etc_facter
   $manage_etc_facter_facts_d      = $::puppet::manage_etc_facter_facts_d
@@ -24,6 +26,10 @@ class puppet::config {
     true    => false,
   }
   $logdest_ensure = $logdest ? {
+    default => present,
+    undef   => absent,
+  }
+  $splaylimit_ensure = $splaylimit ? {
     default => present,
     undef   => absent,
   }
@@ -72,6 +78,24 @@ class puppet::config {
     section => 'agent',
     setting => 'runinterval',
     value   => $runinterval,
+    require => Class['puppet::install'],
+  }
+
+  ini_setting { 'puppet client splay':
+    ensure  => present,
+    path    => "${confdir}/puppet.conf",
+    section => 'agent',
+    setting => 'splay',
+    value   => $splay,
+    require => Class['puppet::install'],
+  }
+
+  ini_setting { 'puppet client splaylimit':
+    ensure  => $splaylimit_ensure,
+    path    => "${confdir}/puppet.conf",
+    section => 'agent',
+    setting => 'splaylimit',
+    value   => $splaylimit,
     require => Class['puppet::install'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,10 @@
 #   Whether or not to send reports
 # @param runinterval [String] Default: '30m'
 #   Sets the runinterval in puppet.conf
+# @param splay [Boolean] Default: false
+#   Sets the splay parameter in puppet.conf
+# @param splaylimit [String] Default: undef
+#   Sets the splaylimit parameter in puppet.conf
 # @param structured_facts [Boolean] Default: false
 #   Sets whether or not to enable [structured_facts](http://docs.puppetlabs.com/facter/2.0/fact_overview.html) 
 #   by setting the [stringify_facts](http://docs.puppetlabs.com/references/3.6.latest/configuration.html#stringifyfacts) 
@@ -101,6 +105,8 @@ class puppet (
   $puppet_version                 = 'installed',
   $reports                        = true,
   $runinterval                    = '30m',
+  $splay                          = false,
+  $splaylimit                     = undef,
   $structured_facts               = false,
 ) {
   #input validation
@@ -114,6 +120,7 @@ class puppet (
     $manage_etc_facter_facts_d,
     $manage_repos,
     $reports,
+    $splay,
     $structured_facts,
   )
 
@@ -128,6 +135,7 @@ class puppet (
     $manage_repo_method,
     $puppet_server,
     $puppet_version,
+    $splaylimit,
     $runinterval,
   )
   $manage_repo_types = ['files','package']

--- a/manifests/profile/agent.pp
+++ b/manifests/profile/agent.pp
@@ -62,6 +62,10 @@
 #   Whether or not to send reports
 # @param runinterval [String] Default: '30m'
 #   Sets the runinterval in puppet.conf
+# @param splay [Boolean] Default: false
+#   Sets the splay parameter in puppet.conf
+# @param splaylimit [String] Default: undef
+#   Sets the splaylimit parameter in puppet.conf
 # @param structured_facts [Boolean] Default: false
 #   Sets whether or not to enable [structured_facts](http://docs.puppetlabs.com/facter/2.0/fact_overview.html) 
 #   by setting the [stringify_facts](http://docs.puppetlabs.com/references/3.6.latest/configuration.html#stringifyfacts) 
@@ -97,6 +101,8 @@ class puppet::profile::agent (
   $puppet_version                 = 'installed',
   $reports                        = true,
   $runinterval                    = '30m',
+  $splay                          = false,
+  $splaylimit                     = undef,
   $structured_facts               = false,
 ) {
   class { '::puppet':
@@ -125,6 +131,8 @@ class puppet::profile::agent (
     puppet_version                 => $puppet_version,
     reports                        => $reports,
     runinterval                    => $runinterval,
+    splay                          => $splay,
+    splaylimit                     => $splaylimit,
     structured_facts               => $structured_facts,
   }
 

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -70,6 +70,15 @@ describe 'puppet::config', :type => :class do
             'value'=>'30m'
           })
         end
+        it "should set the puppet agent splay parameter in #{confdir}/puppet.conf" do
+          should contain_ini_setting('puppet client splay').with({
+            'ensure'=>'present',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'agent',
+            'setting'=>'splay',
+            'value'=>false
+          })
+        end
         it "should setup puppet.conf to support structured_facts in #{confdir}/puppet.conf" do
           should contain_ini_setting('puppet client structured_facts').with({
             'ensure'=>'present',
@@ -183,6 +192,28 @@ describe 'puppet::config', :type => :class do
           })
         end
       end# custom runinterval
+      context 'when ::puppet::splay is true' do
+        let(:pre_condition) {"class{'::puppet': splay => true}"}
+        it "should properly set the splay setting in #{confdir}/puppet.conf" do
+          should contain_ini_setting('puppet client splay').with({
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'agent',
+            'setting'=>'splay',
+            'value'=>true
+          })
+        end
+      end# custom splay
+      context 'when ::puppet::splaylimit has a non-standard value' do
+        let(:pre_condition) {"class{'::puppet': splaylimit => 'BOGON'}"}
+        it "should properly set the splaylimit setting in #{confdir}/puppet.conf" do
+          should contain_ini_setting('puppet client splaylimit').with({
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'agent',
+            'setting'=>'splaylimit',
+            'value'=>'BOGON'
+          })
+        end
+      end# custom splaylimit
       context 'when ::puppet::structured_facts is false' do
         let(:pre_condition) {"class{'::puppet': structured_facts => false}"}
         it "should properly set the stringify_facts setting in puppet.conf" do

--- a/spec/classes/puppet_spec.rb
+++ b/spec/classes/puppet_spec.rb
@@ -28,7 +28,7 @@ describe 'puppet', :type => :class do
      end
    end#arrays
 
-    ['allinone','cfacter','enable_devel_repo','enabled','enable_repo','manage_etc_facter','manage_etc_facter_facts_d','manage_repos','reports','structured_facts'].each do |bools|
+    ['allinone','cfacter','enable_devel_repo','enabled','enable_repo','manage_etc_facter','manage_etc_facter_facts_d','manage_repos','reports','splay','structured_facts'].each do |bools|
       context "when the #{bools} parameter is not an boolean" do
         let(:params) {{bools => "BOGON"}}
         it 'should fail' do
@@ -64,7 +64,7 @@ describe 'puppet', :type => :class do
       end
     end#regexes
 
-    ['agent_version','ca_server','collection','environment','facter_version','hiera_version','preferred_serialization_format','puppet_server','puppet_version','runinterval'].each do |strings|
+    ['agent_version','ca_server','collection','environment','facter_version','hiera_version','preferred_serialization_format','puppet_server','puppet_version','runinterval','splaylimit'].each do |strings|
       context "when the #{strings} parameter is not a string" do
         let(:params) {{strings => false }}
         it 'should fail' do


### PR DESCRIPTION
When running in daemon mode, the splay and splaylimit parameters are useful for making sure your nodes don't all hit the puppetmaster at once.

I think I've caught all the documentation and spec tests, let me know if I've missed something!