### PR TITLE
Add masterport

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ The `puppet` class is responsible for validating some of our parameters, and ins
   * **puppet_server**: (*string* Default: `puppet`)
 
     The hostname or fqdn of the puppet server that the agent should communicate with.
+    
+  * **puppet_server_port**: (*string* Default: undef)
+
+    The port of the puppet server that the agent should communicate with.
 
   * **puppet_version**: (*string* Default: `installed`)
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,7 @@ class puppet::config {
   $logdest                        = $::puppet::logdest
   $preferred_serialization_format = $::puppet::preferred_serialization_format
   $puppet_server                  = $::puppet::puppet_server
+  $puppet_server_port             = $::puppet::puppet_server_port
   $reports                        = $::puppet::reports
   $runinterval                    = $::puppet::runinterval
   $structured_facts               = $::puppet::structured_facts
@@ -35,6 +36,17 @@ class puppet::config {
     setting => 'server',
     value   => $puppet_server,
     require => Class['puppet::install'],
+  }
+  
+  if ($puppet_server_port != undef) {
+    ini_setting { 'puppet server_port':
+      ensure  => present,
+      path    => "${confdir}/puppet.conf",
+      section => 'main',
+      setting => 'masterport',
+      value   => $puppet_server_port,
+      require => Class['puppet::install'],
+    }
   }
 
   if ($ca_server != undef) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,8 @@
 #   Sets the method for managing the repo files
 # @param puppet_server [String] Default: 'puppet'
 #   The hostname or fqdn of the puppet server that the agent should communicate with.
+# @param puppet_server_port [String] Default: undef
+#   The port of the puppet server that the agent should communicate with.
 # @param preferred_serialization_format [String] Default: 'pson'
 #   The serialization format to use for communication with the puppet server.
 #   WARNING: Setting this to msgpack is experimental! Please enable with care.
@@ -98,6 +100,7 @@ class puppet (
   $manage_repo_method             = 'files',
   $preferred_serialization_format = 'pson',
   $puppet_server                  = 'puppet',
+  $puppet_server_port             = undef,
   $puppet_version                 = 'installed',
   $reports                        = true,
   $runinterval                    = '30m',
@@ -127,6 +130,7 @@ class puppet (
     $logdest,
     $manage_repo_method,
     $puppet_server,
+    $puppet_server_port,
     $puppet_version,
     $runinterval,
   )

--- a/manifests/profile/agent.pp
+++ b/manifests/profile/agent.pp
@@ -53,6 +53,8 @@
 #   Sets the method for managing the repo files
 # @param puppet_server [String] Default: 'puppet'
 #   The hostname or fqdn of the puppet server that the agent should communicate with.
+# @param puppet_server_port [String] Default: undef
+#   The port of the puppet server that the agent should communicate with.
 # @param preferred_serialization_format [String] Default: 'pson'
 #   The serialization format to use for communication with the puppet server.
 #   WARNING: Setting this to msgpack is experimental! Please enable with care.
@@ -94,6 +96,7 @@ class puppet::profile::agent (
   $manage_repo_method             = 'files',
   $preferred_serialization_format = 'pson',
   $puppet_server                  = 'puppet',
+  $puppet_server_port             = undef,
   $puppet_version                 = 'installed',
   $reports                        = true,
   $runinterval                    = '30m',
@@ -122,6 +125,7 @@ class puppet::profile::agent (
     manage_repo_method             => $manage_repo_method,
     preferred_serialization_format => $preferred_serialization_format,
     puppet_server                  => $puppet_server,
+    puppet_server_port             => $puppet_server_port,
     puppet_version                 => $puppet_version,
     reports                        => $reports,
     runinterval                    => $runinterval,


### PR DESCRIPTION
Add ability to specify parameter `masterport` on puppet.conf agent section allowing the agents to call a different port than the default one.

The parameter defaults to `undef` to use default puppet port if no puppet_server_port parameter is specified.

In our specific case we need it to change the port to 443 so we can pass through an ssl proxy in front of our masters that act as our CA authority.
