### PR TITLE
Add certname

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ or
       cfacter => true
     }
 
+### Set custom agent certname
+
+    class { '::puppet::profile::agent':
+      certname => 'agent.domain.com'
+    }
+
 ### Use packages for repository management
 
     class { '::puppet::profile::agent':
@@ -273,6 +279,10 @@ The `puppet` class is responsible for validating some of our parameters, and ins
   * **cfacter**: (*bool* Default: `false`)
 
     Whether or not to use cfacter instead of facter.
+  
+  * **certname**: (*string* Default: `undef`)
+
+    Set a custom certname for the agent.
 
   * **collection**: (*string* Default: `undef`)
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,7 @@ class puppet::config {
   $sysconfigdir                   = $::puppet::defaults::sysconfigdir
   $ca_server                      = $::puppet::ca_server
   $cfacter                        = $::puppet::cfacter
+  $certname                       = $::puppet::certname
   $environment                    = $::puppet::environment
   $logdest                        = $::puppet::logdest
   $preferred_serialization_format = $::puppet::preferred_serialization_format
@@ -55,6 +56,17 @@ class puppet::config {
     setting => 'cfacter',
     value   => $cfacter,
     require => Class['puppet::install'],
+  }
+  
+  if ($certname != undef) {
+    ini_setting { 'agent certname':
+      ensure  => present,
+      path    => "${confdir}/puppet.conf",
+      section => 'main',
+      setting => 'certname',
+      value   => $certname,
+      require => Class['puppet::install'],
+    }
   }
 
   ini_setting { 'puppet client environment':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,8 @@
 #   Server to use as the CA server for all agents.
 # @param cfacter [Boolean] Default: false
 #   Whether or not to use cfacter instead of facter.
+# @param cfacter [String] Default: undef
+#   Set a custom certname for the agent.
 # @param collection [String] Default: undef
 #   Declares the collection repository to use.
 # @param custom_facts [Hash] Default: undef
@@ -81,6 +83,7 @@ class puppet (
   $agent_version                  = 'installed',
   $ca_server                      = undef,
   $cfacter                        = false,
+  $certname                       = undef,
   $collection                     = undef,
   $custom_facts                   = undef,
   $devel_repo                     = false,

--- a/manifests/profile/agent.pp
+++ b/manifests/profile/agent.pp
@@ -19,6 +19,8 @@
 #   Declares the version of the puppet-agent all-in-one package to install.
 # @param cfacter [Boolean] Default: false
 #   Whether or not to use cfacter instead of facter.
+# @param certname [String] Default: undef
+#   Set a custom certname for the agent.
 # @param collection [String] Default: undef
 #   Declares the collection repository to use.
 # @param custom_facts [Hash] Default: undef
@@ -78,6 +80,7 @@ class puppet::profile::agent (
   $agent_version                  = 'installed',
   $ca_server                      = undef,
   $cfacter                        = false,
+  $certname                       = undef,
   $collection                     = undef,
   $custom_facts                   = undef,
   $enabled                        = true,
@@ -106,6 +109,7 @@ class puppet::profile::agent (
     agent_version                  => $agent_version,
     ca_server                      => $ca_server,
     cfacter                        => $cfacter,
+    certname                       => $certname,
     collection                     => $collection,
     custom_facts                   => $custom_facts,
     enabled                        => $enabled,


### PR DESCRIPTION
Adding ability to specify custom certname for agents on the main section of the puppet.conf file.

We need this to format our agent certificates matching the way we generate our custom machine CA since they don't match our hostnames.
