### PR TITLE
Feature: Configure agents using SRV records

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,24 @@ The `puppet` class is responsible for validating some of our parameters, and ins
 
     **It is important to note that this boolean operates in reverse.** Setting stringify_facts to **false** is required to **permit** structured facts. This is why this parameter does not directly correlate with the configuration key.
 
+  * **use_srv_records**: (*bool* Default: 'false')
+
+    Enables the use of srv_records for Puppetmaster/CA selection
+
+  * **srv_domain**: (*string* Default: undef)
+
+    Sets the srv_domain to use when use_srv_domains is set to true
+
+  * **pluginsource**: (*string* Default: undef)
+
+    Sets the pluginsource value in puppet.conf. Useful when using SRV records
+and agents on versions less than 4.0 (See https://tickets.puppetlabs.com/browse/PUP-1035)
+
+  * **pluginfactsource**: (*string* Default: undef)
+
+    Sets the pluginfactsource value in puppet.conf. Useful when using SRV
+records and agents on versions less than 4.0 (See https://tickets.puppetlabs.com/browse/PUP-1035)
+
 ----
 
 ####[Private] Class: **puppet::agent**

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,10 @@ class puppet::config {
   $structured_facts               = $::puppet::structured_facts
   $manage_etc_facter              = $::puppet::manage_etc_facter
   $manage_etc_facter_facts_d      = $::puppet::manage_etc_facter_facts_d
+  $use_srv_records                = $::puppet::use_srv_records
+  $srv_domain                     = $::puppet::srv_domain
+  $pluginsource                   = $::puppet::pluginsource
+  $pluginfactsource               = $::puppet::pluginfactsource
 
   $stringify_facts = $structured_facts ? {
     default => true,
@@ -28,8 +32,36 @@ class puppet::config {
     undef   => absent,
   }
 
+  if ($use_srv_records) {
+    $_ensure_puppet_server = 'absent'
+    $_ensure_use_srv_records = 'present'
+    $_ensure_srv_domain = 'present'
+  } else {
+    $_ensure_puppet_server = 'present'
+    $_ensure_use_srv_records = 'absent'
+    $_ensure_srv_domain = 'absent'
+  }
+
+  if ($ca_server) {
+    $_ensure_ca_server = 'present'
+  } else {
+    $_ensure_ca_server = 'absent'
+  }
+
+  if ($pluginsource) {
+    $_ensure_pluginsource = 'present'
+  } else {
+    $_ensure_pluginsource = 'absent'
+  }
+
+  if ($pluginfactsource) {
+    $_ensure_pluginfactsource = 'present'
+  } else {
+    $_ensure_pluginfactsource = 'absent'
+  }
+
   ini_setting { 'puppet client server':
-    ensure  => present,
+    ensure  => $_ensure_puppet_server,
     path    => "${confdir}/puppet.conf",
     section => 'agent',
     setting => 'server',
@@ -37,15 +69,45 @@ class puppet::config {
     require => Class['puppet::install'],
   }
 
-  if ($ca_server != undef) {
-    ini_setting { 'puppet ca_server':
-      ensure  => present,
-      path    => "${confdir}/puppet.conf",
-      section => 'main',
-      setting => 'ca_server',
-      value   => $ca_server,
-      require => Class['puppet::install'],
-    }
+  ini_setting { 'puppet use_srv_records':
+    ensure  => $_ensure_use_srv_records,
+    path    => "${confdir}/puppet.conf",
+    section => 'main',
+    setting => 'use_srv_records',
+    value   => $use_srv_records,
+  }
+
+  ini_setting { 'puppet srv_domain':
+    ensure  => $_ensure_srv_domain,
+    path    => "${confdir}/puppet.conf",
+    section => 'main',
+    setting => 'srv_domain',
+    value   => $srv_domain,
+  }
+
+  ini_setting { 'puppet pluginsource':
+    ensure  => $_ensure_pluginsource,
+    path    => "${confdir}/puppet.conf",
+    section => 'main',
+    setting => 'pluginsource',
+    value   => $pluginsource,
+  }
+
+  ini_setting { 'puppet pluginfactsource':
+    ensure  => $_ensure_pluginfactsource,
+    path    => "${confdir}/puppet.conf",
+    section => 'main',
+    setting => 'pluginfactsource',
+    value   => $pluginfactsource,
+  }
+
+  ini_setting { 'puppet ca_server':
+    ensure  => $_ensure_ca_server,
+    path    => "${confdir}/puppet.conf",
+    section => 'main',
+    setting => 'ca_server',
+    value   => $ca_server,
+    require => Class['puppet::install'],
   }
 
   ini_setting { 'puppet client cfacter':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,19 +1,19 @@
-# The main puppet class is responsible for validating some of our parameters, 
+# The main puppet class is responsible for validating some of our parameters,
 # and instantiating the puppet::facts, puppet::repo, pupppet::install,
 # puppet::config and puppet::agent classes.
 #
 # @puppet when declaring the puppet class
 #   include puppet
 #
-# @param allinone [Boolean] Default: false 
+# @param allinone [Boolean] Default: false
 #   Whether to use the new collections
-# @param agent_cron_hour [String] Default: '*' 
+# @param agent_cron_hour [String] Default: '*'
 #   The hour to run the agent cron. Valid values are `0-23`
 # @param agent_cron_min [String/Array] Default: 'two_times_an_hour'
 #   This param accepts any value accepted by the [cron native type](http://docs.puppetlabs.com/references/latest/type.html#cron-attribute-minute),
-#   as well as two special options: `two_times_an_hour`, and `four_times_an_hour`. 
+#   as well as two special options: `two_times_an_hour`, and `four_times_an_hour`.
 #   These specials use [fqdn_rand](http://docs.puppetlabs.com/references/latest/function.html#fqdnrand)
-#   to generate a random minute array on the selected interval. 
+#   to generate a random minute array on the selected interval.
 #   This should distribute the load more evenly on your puppetmasters.
 # @param agent_version [String] Default: 'installed'
 #   Declares the version of the puppet-agent all-in-one package to install.
@@ -32,7 +32,7 @@
 # @param enable_devel_repo [Boolean] Default: false
 #   This param will replace `devel_repo` in 2.x.
 #   It conveys to puppet::repo::apt whether or not to add the devel apt repo source.
-#   When `devel_repo` is false, `enable_devel_repo` is consulted for enablement. 
+#   When `devel_repo` is false, `enable_devel_repo` is consulted for enablement.
 #   This gives `devel_repo` backwards compatability at the cost of some confusion if you set `devel_repo` to true, and `enable_devel_repo` to false.
 # @param enable_mechanism [String] Default: 'service'
 #   A toggle which permits the option of running puppet as a service, or as a cron job.
@@ -67,12 +67,29 @@
 # @param runinterval [String] Default: '30m'
 #   Sets the runinterval in puppet.conf
 # @param structured_facts [Boolean] Default: false
-#   Sets whether or not to enable [structured_facts](http://docs.puppetlabs.com/facter/2.0/fact_overview.html) 
-#   by setting the [stringify_facts](http://docs.puppetlabs.com/references/3.6.latest/configuration.html#stringifyfacts) 
+#   Sets whether or not to enable [structured_facts](http://docs.puppetlabs.com/facter/2.0/fact_overview.html)
+#   by setting the [stringify_facts](http://docs.puppetlabs.com/references/3.6.latest/configuration.html#stringifyfacts)
 #   variable in puppet.conf.
 #   **It is important to note that this boolean operates in reverse.
-#   ** Setting stringify_facts to **false** is required to **permit** structured facts. 
+#   ** Setting stringify_facts to **false** is required to **permit** structured facts.
 #   This is why this parameter does not directly correlate with the configuration key.
+# @param use_srv_records [Boolean] Default: false
+#   Enables the use of SRV records for Puppetmaster/CA selection
+#   **If set to true srv_domain must also be set. This also ignores
+#   puppet_server value and removes it from puppet.conf
+# @param srv_domain [String] Default: undef
+#   Chooses the domain to use if use_srv_records is set to true. Required if
+#   use_srv_records is true.
+# @param pluginsource [String] Default: undef
+#   Specifies what server to use for syncing plugins. This is useful if you are
+#   using SRV records and still have agents on < 4.0 as pluginsync will fail
+#   unless set to a specific value (See
+#   https://tickets.puppetlabs.com/browse/PUP-1035)
+# @param pluginfactsource [String] Default: undef
+#   If specified it will set the pluginfactsource value in puppet.conf. This is
+#   useful if you are using SRV records and still have agents on < 4.0 as
+#   pluginfactsync will fail to run using the default value (See
+#   https://tickets.puppetlabs.com/browse/PUP-1035)
 
 class puppet (
   $allinone                       = false,
@@ -102,6 +119,10 @@ class puppet (
   $reports                        = true,
   $runinterval                    = '30m',
   $structured_facts               = false,
+  $use_srv_records                = false,
+  $srv_domain                     = undef,
+  $pluginsource                   = undef,
+  $pluginfactsource               = undef,
 ) {
   #input validation
   validate_bool(

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -51,6 +51,18 @@ describe 'puppet::config', :type => :class do
             'setting'=>'server',
             'value'=>'puppet'
           })
+          should contain_ini_setting('puppet use_srv_records').with({
+            'ensure'=>'absent',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'main',
+            'setting'=>'use_srv_records',
+          })
+          should contain_ini_setting('puppet srv_domain').with({
+            'ensure'=>'absent',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'main',
+            'setting'=>'srv_domain',
+          })
         end
         it "should properly set the environment setting in #{confdir}/puppet.conf" do
           should contain_ini_setting('puppet client environment').with({
@@ -105,10 +117,23 @@ describe 'puppet::config', :type => :class do
             'ensure'  => 'present',
             'path'    => "#{confdir}/puppet.conf",
             'section' => 'main',
+            'setting' => 'ca_server',
             'value'   => 'bogon.domain.com'
           })
         end
-      end# ca_server
+      end# ca_server is set
+
+      context 'when ::puppet::ca_server is not set' do
+        let(:pre_condition){"class{'::puppet':}"}
+        it "should unset ca_server" do
+          should contain_ini_setting('puppet ca_server').with({
+            'ensure' => 'absent',
+            'path'    => "#{confdir}/puppet.conf",
+            'section' => 'main',
+            'setting' => 'ca_server',
+          })
+        end
+      end # ca_server is not set
 
       context 'when ::puppet::cfacter is true' do
         let(:pre_condition){"class{'::puppet': cfacter => true}"}
@@ -206,6 +231,82 @@ describe 'puppet::config', :type => :class do
           })
         end
       end# reports
+
+      context 'when $::puppet::use_srv_records is true and srv_domain is foo.com' do
+        let(:pre_condition){"class{'::puppet': enabled => true, use_srv_records => true, srv_domain => 'foo.com'}"}
+        it'should set use_srv_records and srv_domain in puppet.conf' do
+          should contain_ini_setting('puppet use_srv_records').with({
+            'ensure' => 'present',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'main',
+            'setting'=>'use_srv_records',
+            'value'=>'true',
+          })
+          should contain_ini_setting('puppet srv_domain').with({
+            'ensure' => 'present',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'main',
+            'setting'=>'srv_domain',
+            'value'=>'foo.com',
+          })
+          should contain_ini_setting('puppet client server').with({
+            'ensure' => 'absent',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'agent',
+            'setting'=>'server',
+          })
+        end
+      end # puppet::use_srv_records
+
+      context 'when $::puppet::pluginsource is set' do
+        let(:pre_condition){"class{'::puppet': enabled => true, pluginsource => 'foo'}"}
+        it 'should set pluginsource in puppet.conf' do
+          should contain_ini_setting('puppet pluginsource').with({
+            'ensure'=>'present',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'main',
+            'setting'=>'pluginsource',
+            'value'=>'foo',
+          })
+        end
+      end # puppet::pluginsource is set
+
+      context 'when $::puppet::pluginsource is not set' do
+        let(:pre_condition){"class{'::puppet': enabled => true}"}
+        it 'should unset pluginsource in puppet.conf' do
+          should contain_ini_setting('puppet pluginsource').with({
+            'ensure'=>'absent',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'main',
+            'setting'=>'pluginsource',
+          })
+        end
+      end # puppet::pluginsource is undef
+
+      context 'when $::puppet::pluginfactsource is set' do
+        let(:pre_condition){"class{'::puppet': enabled => true, pluginfactsource => 'foo'}"}
+        it 'should set pluginsource in puppet.conf' do
+          should contain_ini_setting('puppet pluginfactsource').with({
+            'ensure'=>'present',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'main',
+            'setting'=>'pluginfactsource',
+            'value'=>'foo',
+          })
+        end
+      end # puppet::pluginfactsource is set
+
+      context 'when $::puppet::pluginfactsource is undef' do
+        let(:pre_condition){"class{'::puppet': enabled => true,}"}
+        it 'should unset pluginsource in puppet.conf' do
+          should contain_ini_setting('puppet pluginfactsource').with({
+            'ensure'=>'absent',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'main',
+            'setting'=>'pluginfactsource',
+          })
+        end
+      end # puppet::pluginfactsource is undef
 
     end
   end


### PR DESCRIPTION
This PR includes the ability to configure the following settings in puppet.conf:

- use_srv_records
- srv_domain
- pluginsource
- pluginfactsource

This is useful for teams that want to use the SRV lookups for Puppetmaster lists. It also changes some logic for a few settings to make transitioning from defined Puppetmasters to SRV records. 