### PR TITLE
Add a dependency on ::apt::update to successfully install the agent.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,7 +20,7 @@ class puppet::install {
 
   package { $agent_package:
     ensure  => $package_ensure,
-    require => Class['::puppet::install::deps']
+    require => Class['::puppet::install::deps', '::apt::update']
   }
 
 }


### PR DESCRIPTION
When rolling out this module on a new agent, the first puppet run will fail because the puppetlabs-PC1 repository hasn't been fetched yet.