### PR TITLE
In custom facters extended key values (String, Array, Hash).

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ group :test do
   gem 'metadata-json-lint',                               :require => false
   gem 'simplecov',                                        :require => false
   gem 'json',                   '1.8.3',                  :require => false
+  gem 'json_pure',              '1.8.3',                  :require => false
+  gem 'rubocop',                '0.41.2',                 :require => false
   gem "puppet-blacksmith",                                :require => false
   gem 'pry',                    '<= 0.9.8',               :require => false
   gem 'puppet-lint',                                      :require => false

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -11,7 +11,7 @@ define puppet::fact (
   $facterbasepath = $::puppet::defaults::facterbasepath
 
   unless is_string($value) or is_array($value) or is_hash($value) {
-    fail("Param \$value of define Puppet::Fact must be Sring or Array or Hash!")
+    warning("Param \$value of define Puppet::Fact must be Sring or Array or Hash!")
   }
 
   file { "${facterbasepath}/facts.d/${title}.yaml":

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -11,7 +11,7 @@ define puppet::fact (
   $facterbasepath = $::puppet::defaults::facterbasepath
 
   unless is_string($value) or is_array($value) or is_hash($value) {
-    warning("Param \$value of define Puppet::Fact must be Sring or Array or Hash!")
+    warning("Param \$value of resource Puppet::Fact['${title}'] must be Sring or Array or Hash!")
   }
 
   file { "${facterbasepath}/facts.d/${title}.yaml":

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -10,6 +10,10 @@ define puppet::fact (
   include ::puppet::defaults
   $facterbasepath = $::puppet::defaults::facterbasepath
 
+  unless is_string($value) or is_array($value) or is_hash($value) {
+    fail("Param \$value of define Puppet::Fact must be Sring or Array or Hash!")
+  }
+
   file { "${facterbasepath}/facts.d/${title}.yaml":
     ensure  => $ensure,
     owner   => 'root',

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -16,6 +16,17 @@ class puppet::facts (
     validate_hash($custom_facts)
   }
 
+  if ( versioncmp($::puppetversion, '4.0.0') >= 0 ) {
+    $custom_facts.each |$custom_fact, $custom_fact_value| {
+      unless is_string($custom_fact_value) or is_array($custom_fact_value) or is_hash($custom_fact_value) {
+        warning("Value of custom fact '${custom_fact}' must be Sring or Array or Hash!")
+      }
+    }
+  } else {
+    $custom_facts_values = values($custom_facts)
+    ::puppet::facts::validation { $custom_facts_values: }
+  }
+
   file { "${facterbasepath}/facts.d/local.yaml":
     ensure  => file,
     owner   => 'root',

--- a/manifests/facts/validation.pp
+++ b/manifests/facts/validation.pp
@@ -1,0 +1,9 @@
+# Define: puppet::facts::validation
+#
+# Validation values of parametr custom_facts from class: puppet::facts
+#
+define puppet::facts::validation {
+  unless is_string($title) or is_array($title) or is_hash($title) {
+    warning("Values of custom_facts must be Sring or Array or Hash!")
+  }
+}

--- a/spec/classes/puppet_facts_spec.rb
+++ b/spec/classes/puppet_facts_spec.rb
@@ -110,16 +110,48 @@ describe 'puppet::facts', :type => :class do
           end
         end
       end#no params
-      context 'when the custom_facts parameter is properly set' do
+      context 'when the custom_facts parameter is properly set key values is string' do
         let(:params) {{'custom_facts' => {'key1' => 'val1', 'key2' => 'val2'}}}
         it 'should iterate through the hash and properly populate the local_facts.yaml file' do
           should contain_file("#{facterbasepath}/facts.d/local.yaml").with_content(
-            /key1: \"val1\"/
+            /key1: \'val1\'/
           ).with_content(
-            /key2: \"val2\"/
+            /key2: \'val2\'/
           )
         end
-      end#custom_facts
+      end#custom_facts set key values is string
+      context 'when the custom_facts parameter is properly set key values is array' do
+        let(:params) {{'custom_facts' => {'key1' => [ 'val11', 'val12' ], 'key2' => [ 'val21', 'val22']}}}
+        it 'should iterate through the hash and properly populate the local_facts.yaml file' do
+          should contain_file("#{facterbasepath}/facts.d/local.yaml").with_content(
+            /^key1:$/
+          ).with_content(
+            /^  - \'val11\'$/
+          ).with_content(
+            /^  - \'val12\'$/
+          ).with_content(
+            /^key2:$/
+          ).with_content(
+            /^  - \'val21\'$/
+          ).with_content(  
+            /^  - \'val22\'$/
+          )
+        end
+      end#custom_facts set key values is array
+      context 'when the custom_facts parameter is properly set key values is hash' do
+        let(:params) {{'custom_facts' => {'key1' => { 'key11' => 'val11' }, 'key2' => { 'key21' => 'val21'}}}}
+        it 'should iterate through the hash and properly populate the local_facts.yaml file' do
+          should contain_file("#{facterbasepath}/facts.d/local.yaml").with_content(
+            /^key1:$/
+          ).with_content(
+            /^  key11: \'val11\'$/
+          ).with_content(  
+            /^key2:$/
+          ).with_content(
+            /^  key21: \'val21\'$/
+          )
+        end
+      end#custom_facts set key values is hash
     end
   end
 end

--- a/spec/defines/fact_spec.rb
+++ b/spec/defines/fact_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe 'puppet::fact', :type => :define do
-  context 'input validation' do
+  context 'input validation with type value is string' do
       let (:title) { 'my_fact'}
       let (:params) {{ 'value' => 'my_val'}}
 #    ['path'].each do |paths|
@@ -50,7 +50,18 @@ describe 'puppet::fact', :type => :define do
 #      end
 #    end#strings
 
-  end#input validation
+  end#input validation with type value is string
+
+  context 'input validation with type value is array' do
+      let (:title) { 'my_fact'}
+      let (:params) {{ 'value' => ['my_val0', 'my_val1']}}
+  end#input validation with type value is array
+
+  context 'input validation with type value is Hash' do
+      let (:title) { 'my_fact'}
+      let (:params) {{ 'value' => {'my_key0' => 'my_val0', 'my_key1' => 'my_val1'}}}
+  end#input validation with type value is hash
+
   on_supported_os({
       :hardwaremodels => ['x86_64'],
       :supported_os   => [
@@ -82,19 +93,45 @@ describe 'puppet::fact', :type => :define do
       else
         facterbasepath  = '/etc/facter'
       end
-      context 'when fed no parameters' do
+      context 'when fed no parameters (value is string)' do
         let (:title) { 'my_fact'}
         let (:params) {{'value' => 'my_val'}}
-        it 'should lay down our fact file as expected' do
+        it 'should lay down our fact file as expected (value is string))' do
           should contain_file("#{facterbasepath}/facts.d/my_fact.yaml").with({
             :path=>"#{facterbasepath}/facts.d/my_fact.yaml",
             :ensure=>"present",
             :owner=>"root",
             :group=>"puppet",
             :mode=>"0640"
-          }).with_content("# custom fact my_fact\n---\nmy_fact: \"my_val\"\n")
+          }).with_content("# custom fact my_fact\n---\nmy_fact: \'my_val\'\n")
         end
-      end#no params
+      end
+      context 'when fed no parameters (value is array)' do
+        let (:title) { 'my_fact'}
+        let (:params) {{'value' => ['my_val0', 'my_val1']}}
+        it 'should lay down our fact file as expected (value is string))' do
+          should contain_file("#{facterbasepath}/facts.d/my_fact.yaml").with({
+            :path=>"#{facterbasepath}/facts.d/my_fact.yaml",
+            :ensure=>"present",
+            :owner=>"root",
+            :group=>"puppet",
+            :mode=>"0640"
+          }).with_content("# custom fact my_fact\n---\nmy_fact:\n  - \'my_val0\'\n  - \'my_val1\'\n")
+        end
+      end
+      context 'when fed no parameters (value is hash)' do
+        let (:title) { 'my_fact'}
+        let (:params) {{'value' => {'my_key0' => 'my_val0', 'my_key1' => 'my_val1'}}}
+        it 'should lay down our fact file as expected (value is string))' do
+          should contain_file("#{facterbasepath}/facts.d/my_fact.yaml").with({
+            :path=>"#{facterbasepath}/facts.d/my_fact.yaml",
+            :ensure=>"present",
+            :owner=>"root",
+            :group=>"puppet",
+            :mode=>"0640"
+          }).with_content("# custom fact my_fact\n---\nmy_fact:\n  my_key0: \'my_val0\'\n  my_key1: \'my_val1\'\n")
+        end
+      end
 
     end
   end

--- a/templates/fact.yaml.erb
+++ b/templates/fact.yaml.erb
@@ -1,3 +1,16 @@
 # custom fact <%= @title %>
 ---
+<%- case @value -%>
+<%- when Hash -%>
+<%= @title %>:
+<%- @value.sort.each do |key,value| -%>
+  <%= key %>: '<%= value %>"
+<%- end -%>
+<%- when Array -%>
+<%= @title %>:
+<%- @value.sort.each do |value| -%>
+  - "<%= value %>"
+<%- end -%>
+<%- else -%>
 <%= @title %>: "<%= @value %>"
+<%- end -%>

--- a/templates/fact.yaml.erb
+++ b/templates/fact.yaml.erb
@@ -4,13 +4,13 @@
 <%- when Hash -%>
 <%= @title %>:
 <%- @value.sort.each do |key,value| -%>
-  <%= key %>: '<%= value %>"
+  <%= key %>: '<%= value %>'
 <%- end -%>
 <%- when Array -%>
 <%= @title %>:
 <%- @value.sort.each do |value| -%>
-  - "<%= value %>"
+  - '<%= value %>'
 <%- end -%>
 <%- else -%>
-<%= @title %>: "<%= @value %>"
+<%= @title %>: '<%= @value %>'
 <%- end -%>

--- a/templates/local_facts.yaml.erb
+++ b/templates/local_facts.yaml.erb
@@ -4,6 +4,19 @@
 ---
 <%- if @custom_facts -%>
 <%- @custom_facts.keys.sort.each do |key| -%>
+<%- case @custom_facts[key] -%>
+<%- when Hash -%>
+<%= key %>:
+<%- @custom_facts[key].sort.each do |key,value| -%>
+  <%= key %>: '<%= value %>"
+<%- end -%>
+<%- when Array -%>
+<%= key %>:
+<%- @custom_facts[key].sort.each do |value| -%>
+  - "<%= value %>"
+<%- end -%>
+<%- else -%>
 <%= key %>: "<%= @custom_facts[key] %>"
+<%- end -%>
 <%- end -%>
 <%- end -%>

--- a/templates/local_facts.yaml.erb
+++ b/templates/local_facts.yaml.erb
@@ -8,15 +8,15 @@
 <%- when Hash -%>
 <%= key %>:
 <%- @custom_facts[key].sort.each do |key,value| -%>
-  <%= key %>: '<%= value %>"
+  <%= key %>: '<%= value %>'
 <%- end -%>
 <%- when Array -%>
 <%= key %>:
 <%- @custom_facts[key].sort.each do |value| -%>
-  - "<%= value %>"
+  - '<%= value %>'
 <%- end -%>
 <%- else -%>
-<%= key %>: "<%= @custom_facts[key] %>"
+<%= key %>: '<%= @custom_facts[key] %>'
 <%- end -%>
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
Added support array and hash in key values of  custom facters.
code manifest:
```
  $title_facters = {
    roles => {
      ensure => present,
      value  => [ 'puppetserver', 'hiera', 'puppetdb', 'postgresql' ],
    },
  }
  create_resources('::puppet::fact', $title_facters)
```
result:
```
#  facter -v
3.3.0 (commit fc9282a2d426f7c8a742fd5b23c4cb06852eee20)
# facter roles
[
  "hiera",
  "postgresql",
  "puppetdb",
  "puppetserver"
]
```