### PR TITLE
Feature "expanded custom facts"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem "rspec-core",             '3.1.7',                  :require => false
-  gem "rspec-puppet",           '2.3.2',                  :require => false
+  gem "rspec-core",             '3.5.1',                  :require => false
+  gem "rspec-puppet",           '2.4.0',                  :require => false
   gem 'puppetlabs_spec_helper', :git => 'https://github.com/puppetlabs/puppetlabs_spec_helper', :require => false
   gem 'rspec-puppet-facts',     '1.3.0',                  :require => false
   gem "puppet-syntax",                                    :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ group :test do
   gem 'metadata-json-lint',                               :require => false
   gem 'simplecov',                                        :require => false
   gem 'json',                   '1.8.3',                  :require => false
+  gem 'json_pure',              '1.8.3',                  :require => false
+  gem 'rubocop',                '0.41.2',                 :require => false
   gem "puppet-blacksmith",                                :require => false
   gem 'pry',                    '<= 0.9.8',               :require => false
   gem 'puppet-lint',                                      :require => false

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -10,6 +10,9 @@ define puppet::fact (
   include ::puppet::defaults
   $facterbasepath = $::puppet::defaults::facterbasepath
 
+  validate_string($title)
+  $facter_data = { "${title}" => $value }
+
   file { "${facterbasepath}/facts.d/${title}.yaml":
     ensure  => $ensure,
     owner   => 'root',

--- a/spec/classes/puppet_facts_spec.rb
+++ b/spec/classes/puppet_facts_spec.rb
@@ -110,16 +110,54 @@ describe 'puppet::facts', :type => :class do
           end
         end
       end#no params
-      context 'when the custom_facts parameter is properly set' do
+      context 'when the custom_facts parameter is properly set key values is string' do
         let(:params) {{'custom_facts' => {'key1' => 'val1', 'key2' => 'val2'}}}
         it 'should iterate through the hash and properly populate the local_facts.yaml file' do
           should contain_file("#{facterbasepath}/facts.d/local.yaml").with_content(
-            /key1: \"val1\"/
+            /---/
           ).with_content(
-            /key2: \"val2\"/
+            /key1: val1/
+          ).with_content(
+            /key2: val2/
           )
         end
-      end#custom_facts
+      end#custom_facts set key values is string
+      context 'when the custom_facts parameter is properly set key values is array' do
+        let(:params) {{'custom_facts' => {'key1' => [ 'val11', 'val12' ], 'key2' => [ 'val21', 'val22']}}}
+        it 'should iterate through the hash and properly populate the local_facts.yaml file' do
+          should contain_file("#{facterbasepath}/facts.d/local.yaml").with_content(
+            /---/
+          ).with_content(
+            /key1:/
+          ).with_content(
+            /- val11/
+          ).with_content(
+            /- val12/
+          ).with_content(
+            /key2:/
+          ).with_content(
+            /- val21/
+          ).with_content(  
+            /- val22/
+          )
+        end
+      end#custom_facts set key values is array
+      context 'when the custom_facts parameter is properly set key values is hash' do
+        let(:params) {{'custom_facts' => {'key1' => { 'key11' => 'val11' }, 'key2' => { 'key21' => 'val21'}}}}
+        it 'should iterate through the hash and properly populate the local_facts.yaml file' do
+          should contain_file("#{facterbasepath}/facts.d/local.yaml").with_content(
+            /---/
+          ).with_content(
+            /key1:/
+          ).with_content(
+            /key11: val11/
+          ).with_content(  
+            /key2:/
+          ).with_content(
+            /key21: val21/
+          )
+        end
+      end#custom_facts set key values is hash
     end
   end
 end

--- a/spec/defines/fact_spec.rb
+++ b/spec/defines/fact_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe 'puppet::fact', :type => :define do
-  context 'input validation' do
+  context 'input validation with type value is string' do
       let (:title) { 'my_fact'}
       let (:params) {{ 'value' => 'my_val'}}
 #    ['path'].each do |paths|
@@ -50,7 +50,18 @@ describe 'puppet::fact', :type => :define do
 #      end
 #    end#strings
 
-  end#input validation
+  end#input validation with type value is string
+
+  context 'input validation with type value is array' do
+      let (:title) { 'my_fact'}
+      let (:params) {{ 'value' => ['my_val0', 'my_val1']}}
+  end#input validation with type value is array
+
+  context 'input validation with type value is hash' do
+      let (:title) { 'my_fact'}
+      let (:params) {{ 'value' => {'my_key0' => 'my_val0', 'my_key1' => 'my_val1'}}}
+  end#input validation with type value is hash
+
   on_supported_os({
       :hardwaremodels => ['x86_64'],
       :supported_os   => [
@@ -82,19 +93,71 @@ describe 'puppet::fact', :type => :define do
       else
         facterbasepath  = '/etc/facter'
       end
-      context 'when fed no parameters' do
+      context 'when fed no parameters (value is string)' do
         let (:title) { 'my_fact'}
         let (:params) {{'value' => 'my_val'}}
-        it 'should lay down our fact file as expected' do
+        it 'should lay down our fact file as expected (value is string))' do
           should contain_file("#{facterbasepath}/facts.d/my_fact.yaml").with({
             :path=>"#{facterbasepath}/facts.d/my_fact.yaml",
             :ensure=>"present",
             :owner=>"root",
             :group=>"puppet",
             :mode=>"0640"
-          }).with_content("# custom fact my_fact\n---\nmy_fact: \"my_val\"\n")
+          }).with_content(
+             /# custom fact my_fact/
+           ).with_content(
+             /---/
+           ).with_content(
+             /my_fact: my_val/
+           )
         end
-      end#no params
+      end
+      context 'when fed no parameters (value is array)' do
+        let (:title) { 'my_fact'}
+        let (:params) {{'value' => ['my_val0', 'my_val1']}}
+        it 'should lay down our fact file as expected (value is array))' do
+          should contain_file("#{facterbasepath}/facts.d/my_fact.yaml").with({
+            :path=>"#{facterbasepath}/facts.d/my_fact.yaml",
+            :ensure=>"present",
+            :owner=>"root",
+            :group=>"puppet",
+            :mode=>"0640"
+          }).with_content(
+            /# custom fact my_fact/
+          ).with_content(
+            /---/
+          ).with_content(
+            /my_fact:/
+          ).with_content(
+            /- my_val0/
+          ).with_content(
+            /- my_val1/
+          )
+        end
+      end
+      context 'when fed no parameters (value is hash)' do
+        let (:title) { 'my_fact'}
+        let (:params) {{'value' => {'my_key0' => 'my_val0', 'my_key1' => 'my_val1'}}}
+        it 'should lay down our fact file as expected (value is hash))' do
+          should contain_file("#{facterbasepath}/facts.d/my_fact.yaml").with({
+            :path=>"#{facterbasepath}/facts.d/my_fact.yaml",
+            :ensure=>"present",
+            :owner=>"root",
+            :group=>"puppet",
+            :mode=>"0640"
+          }).with_content(
+             /# custom fact my_fact/
+           ).with_content(
+             /---/
+           ).with_content(
+             /my_fact:/
+           ).with_content(
+             /my_key0: my_val0/
+           ).with_content(
+             /my_key1: my_val1/
+           )
+        end
+      end
 
     end
   end

--- a/templates/fact.yaml.erb
+++ b/templates/fact.yaml.erb
@@ -1,3 +1,7 @@
 # custom fact <%= @title %>
----
-<%= @title %>: "<%= @value %>"
+<%- require 'yaml' -%>
+<%- if RUBY_VERSION =~ /^1\.8\./ -%>
+<%= YAML::dump(@facter_data) %>
+<%- else -%>
+<%= @facter_data.to_yaml(indentation:2, canonical:false, line_width:-1) %>
+<%- end -%>

--- a/templates/local_facts.yaml.erb
+++ b/templates/local_facts.yaml.erb
@@ -1,9 +1,9 @@
 # custom facts for <%= @clientcert %>
 # FQDN <%= @fqdn %>
 # Environment <%= @environment %>
----
-<%- if @custom_facts -%>
-<%- @custom_facts.keys.sort.each do |key| -%>
-<%= key %>: "<%= @custom_facts[key] %>"
-<%- end -%>
+<%- require 'yaml' -%>
+<%- if RUBY_VERSION =~ /^1\.8\./ -%>
+<%= YAML::dump(@custom_facts) %>
+<%- else -%>
+<%= @custom_facts.to_yaml(indentation:2, canonical:false, line_width:-1) %>
 <%- end -%>


### PR DESCRIPTION
New feature "expanded custom facts"
Puppet code:
```
  $title_facters = {
    my_fact => {
      ensure => present,
      value  =>
        ['my_val0', 'my_val1'],
    },
    my_fact2 => {
      ensure => present,
      value  => {
        key1 => [
          'val11',
          'val12',
        ],
        key2 => {
          key21 => 'val211',
          key22 => [
            'val221',
            'val222',
          ],
        },
      },
    },
  }
  create_resources('::puppet::fact', $title_facters)
```
facters:
```
# facter -v
3.3.0 (commit fc9282a2d426f7c8a742fd5b23c4cb06852eee20)
# facter my_fact
[
  "my_val0",
  "my_val1"
]
# facter my_fact2
{
  key1 => [
    "val11",
    "val12"
  ],
  key2 => {
    key21 => "val211",
    key22 => [
      "val221",
      "val222"
    ]
  }
}
# facter my_fact2.key1
[
  "val11",
  "val12"
]
# facter my_fact2.key2
{
  key21 => "val211",
  key22 => [
    "val221",
    "val222"
  ]
}
```