### PR TITLE
Correcting hiera paths

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -32,11 +32,6 @@ class puppet::defaults {
     $confdir                   = '/etc/puppetlabs/puppet'
     $codedir                   = '/etc/puppetlabs/code'
     $basemodulepath            = "${codedir}/modules:${confdir}/modules"
-    $hiera_backends            = {
-      'yaml' => {
-        'datadir' => '/etc/puppetlabs/code/hieradata/%{environment}'
-      }
-    }
     $facterbasepath            = '/opt/puppetlabs/facter'
     $reports_dir               = '/opt/puppetlabs/server/data/reports'
     $terminus_package          = 'puppetdb-termini'
@@ -48,11 +43,6 @@ class puppet::defaults {
     $confdir                   = '/etc/puppet'
     $codedir                   = '/etc/puppet'
     $basemodulepath            = "${confdir}/modules:/usr/share/puppet/modules"
-    $hiera_backends            = {
-      'yaml' => {
-        'datadir' => '/etc/puppet/hieradata/%{environment}'
-      }
-    }
     $facterbasepath            = '/etc/facter'
     $reports_dir               = '/var/lib/puppet/reports'
     $terminus_package          = 'puppetdb-terminus'
@@ -65,6 +55,11 @@ class puppet::defaults {
   $autosign_file             = "${confdir}/autosign.conf"
   $environmentpath           = "${codedir}/environments"
   $hiera_eyaml_key_directory = "${codedir}/hiera_eyaml_keys"
-  $hieradata_path            = "${confdir}/hieradata"
+  $hieradata_path            = "${::environmentpath}/%{environment}/hieradata"
+  $hiera_backends            = {
+    'yaml' => {
+      'datadir' => "${::environmentpath}/%{environment}/hieradata"
+    }
+  }
 
 }

--- a/manifests/master/hiera.pp
+++ b/manifests/master/hiera.pp
@@ -4,7 +4,6 @@ class puppet::master::hiera {
   include ::puppet::master
   include ::puppet::defaults
 
-  $codedir                            = $puppet::defaults::codedir
   $env_owner                          = $puppet::master::env_owner
   $eyaml_keys                         = $puppet::master::eyaml_keys
   $hiera_backends                     = $puppet::master::hiera_backends
@@ -18,7 +17,7 @@ class puppet::master::hiera {
   $hiera_merge_behavior               = $puppet::master::hiera_merge_behavior
 
   if ($manage_hiera_config == true) {
-    file { "${codedir}/hiera.yaml":
+    file { "${::confdir}/hiera.yaml":
       ensure  => file,
       content => template('puppet/hiera.yaml.erb'),
       owner   => 'root',

--- a/spec/classes/puppet_master_hiera_spec.rb
+++ b/spec/classes/puppet_master_hiera_spec.rb
@@ -45,8 +45,8 @@ describe 'puppet::master::hiera', :type => :class do
 
       context 'when fed no parameters' do
         if Puppet.version =~ /^4\./
-          it "should lay down #{codedir}/hiera.yaml" do
-            should contain_file("#{codedir}/hiera.yaml").with({
+          it "should lay down #{confdir}/hiera.yaml" do
+            should contain_file("#{confdir}/hiera.yaml").with({
               'ensure' =>'file',
               'owner'  =>'root',
               'group'  =>'root',
@@ -72,8 +72,8 @@ describe 'puppet::master::hiera', :type => :class do
             )
           end
         else
-          it "should lay down #{codedir}/hiera.yaml" do
-            should contain_file("#{codedir}/hiera.yaml").with({
+          it "should lay down #{confdir}/hiera.yaml" do
+            should contain_file("#{confdir}/hiera.yaml").with({
               'ensure' =>'file',
               'owner'  =>'root',
               'group'  =>'root',
@@ -104,9 +104,9 @@ describe 'puppet::master::hiera', :type => :class do
 
       context 'when the hiera_backends param has a non-standard value' do
         let(:pre_condition) {"class{'puppet::master': hiera_backends => { 'yaml' => { 'datadir' => '/BOGON'} }"}
-        it "should update #{codedir}/hiera.yaml apropriately" do
+        it "should update #{confdir}/hiera.yaml appropriately" do
           skip 'This does not work as is'
-          should contain_file("#{codedir}/hiera.yaml").with({
+          should contain_file("#{confdir}/hiera.yaml").with({
             :ensure =>'file',
             :owner  =>'root',
             :group  =>'root',
@@ -133,8 +133,8 @@ describe 'puppet::master::hiera', :type => :class do
 
       context 'when the hierarchy param has a non-standard value' do
         let(:pre_condition) {"class{'puppet::master': hiera_hierarchy => ['foo', 'bar', 'baz'] }"}
-        it "should update #{codedir}/hiera.yaml with the specified hierarchy" do
-          should contain_file("#{codedir}/hiera.yaml").with({
+        it "should update #{confdir}/hiera.yaml with the specified hierarchy" do
+          should contain_file("#{confdir}/hiera.yaml").with({
             :ensure => 'file',
             :owner  => 'root',
             :group  => 'root',
@@ -153,8 +153,8 @@ describe 'puppet::master::hiera', :type => :class do
 
       context 'when manage_hiera_config is false' do
         let(:pre_condition) {"class{'::puppet::master': manage_hiera_config => false}"}
-        it "should not manage #{codedir}/hiera.conf" do
-          should_not contain_file("#{codedir}/hiera.yaml")
+        it "should not manage #{confdir}/hiera.conf" do
+          should_not contain_file("#{confdir}/hiera.yaml")
         end
       end# manage_hiera_config false
 
@@ -259,8 +259,8 @@ describe 'puppet::master::hiera', :type => :class do
 
       context 'when the hiera_merge_behavior param is set to native' do
         let(:pre_condition) {"class{'puppet::master': hiera_merge_behavior => 'native' }"}
-        it "should update #{codedir}/hiera.yaml with the merge_behavior set to native" do
-          should contain_file("#{codedir}/hiera.yaml").with({
+        it "should update #{confdir}/hiera.yaml with the merge_behavior set to native" do
+          should contain_file("#{confdir}/hiera.yaml").with({
             :ensure => 'file',
             :owner  => 'root',
             :group  => 'root',
@@ -273,8 +273,8 @@ describe 'puppet::master::hiera', :type => :class do
 
       context 'when the hiera_merge_behavior param is set to deep' do
         let(:pre_condition) {"class{'puppet::master': hiera_merge_behavior => 'deep' }"}
-        it "should update #{codedir}/hiera.yaml with the merge_behavior set to deep" do
-          should contain_file("#{codedir}/hiera.yaml").with({
+        it "should update #{confdir}/hiera.yaml with the merge_behavior set to deep" do
+          should contain_file("#{confdir}/hiera.yaml").with({
             :ensure => 'file',
             :owner  => 'root',
             :group  => 'root',
@@ -287,8 +287,8 @@ describe 'puppet::master::hiera', :type => :class do
 
       context 'when the hiera_merge_behavior param is set to deeper' do
         let(:pre_condition) {"class{'puppet::master': hiera_merge_behavior => 'deeper' }"}
-        it "should update #{codedir}/hiera.yaml with the merge_behavior set to deeper" do
-          should contain_file("#{codedir}/hiera.yaml").with({
+        it "should update #{confdir}/hiera.yaml with the merge_behavior set to deeper" do
+          should contain_file("#{confdir}/hiera.yaml").with({
             :ensure => 'file',
             :owner  => 'root',
             :group  => 'root',


### PR DESCRIPTION
I noticed a few paths related to hiera are incorrect. Let me know what you think.

1. Default yaml backend was wrong. The value is configurable, so I was able to workaround it by specifying my own path.
1. Location of `hiera.yaml` is wrong. This value is not configurable, so I was working around it by creating a symlink from wrong file -> correct file.