### PR TITLE
zack/r10k has been moved to puppet/r10k

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,8 +68,8 @@
       "version_requirement": ">=5.0.0 <6.0.0"
     },
     {
-      "name": "zack/r10k",
-      "version_requirement": ">=2.7.0 <=3.2.0"
+      "name": "puppet/r10k",
+      "version_requirement": ">=4.0.2 <=5.0.0"
     },
     {
       "name": "puppet/puppetboard",


### PR DESCRIPTION
Setting up a new puppet server today, I discovered that zack/r10k was marked as deprecated/EOL (just yesterday!) and has been transferred to the Vox Pupuli "puppet" namespace. It also got some nice updates... so I installed the new one instead.

Then I tried installing your puppet module, and of course it failed because of the dependency conflict. Comparing the code between the old and new versions of the r10K module there are only a few differences, and nothing that appears to be backwards-incompatible in any way.