### PR TITLE
Fix #142

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -66,10 +66,19 @@ class puppet::config {
     $_ensure_pluginfactsource = 'absent'
   }
 
+  ini_setting { 'puppet client server agent':
+    ensure  => absent,
+    path    => "${confdir}/puppet.conf",
+    section => 'agent',
+    setting => 'server',
+    value   => $puppet_server,
+    require => Class['puppet::install'],
+  }
+
   ini_setting { 'puppet client server':
     ensure  => $_ensure_puppet_server,
     path    => "${confdir}/puppet.conf",
-    section => 'agent',
+    section => 'main',
     setting => 'server',
     value   => $puppet_server,
     require => Class['puppet::install'],

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -44,13 +44,22 @@ describe 'puppet::config', :type => :class do
       end
       context 'when fed no parameters' do
         it "should properly set the puppet server setting in #{confdir}/puppet.conf" do
-          should contain_ini_setting('puppet client server').with({
-            'ensure'=>'present',
+          should contain_ini_setting('puppet client server agent').with({
+            'ensure'=>'absent',
             'path'=>"#{confdir}/puppet.conf",
             'section'=>'agent',
             'setting'=>'server',
             'value'=>'puppet'
           })
+          should contain_ini_setting('puppet client server').with({
+            'ensure'=>'present',
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'main',
+            'setting'=>'server',
+            'value'=>'puppet'
+          })
+        end
+        it "should properly set the puppet srv records settings in #{confdir}/puppet.conf" do
           should contain_ini_setting('puppet use_srv_records').with({
             'ensure'=>'absent',
             'path'=>"#{confdir}/puppet.conf",
@@ -187,9 +196,15 @@ describe 'puppet::config', :type => :class do
       context 'when ::puppet::puppet_server has a non-standard value' do
         let(:pre_condition){"class{'::puppet': puppet_server => 'BOGON'}"}
         it "should properly set the server setting in #{confdir}/puppet.conf" do
-          should contain_ini_setting('puppet client server').with({
+          should_not contain_ini_setting('puppet client server').with({
             'path'=>"#{confdir}/puppet.conf",
             'section'=>'agent',
+            'setting'=>'server',
+            'value'=>'BOGON'
+          })
+          should contain_ini_setting('puppet client server').with({
+            'path'=>"#{confdir}/puppet.conf",
+            'section'=>'main',
             'setting'=>'server',
             'value'=>'BOGON'
           })
@@ -283,7 +298,7 @@ describe 'puppet::config', :type => :class do
           should contain_ini_setting('puppet client server').with({
             'ensure' => 'absent',
             'path'=>"#{confdir}/puppet.conf",
-            'section'=>'agent',
+            'section'=>'main',
             'setting'=>'server',
           })
         end


### PR DESCRIPTION
there appears to be a bug in puppet 4.9.4 and 4.10.0
It's use of the server setting is inconsistent.
If the server is set in main the agent and manual runs use the same server value
But if it's set in the agent section the agent ignores it