### PR TITLE
Remove tests and requirements for puppet 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,14 @@ script: bundle exec rake test
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.2" HIERA_GEM_VERSION="~> 1.3"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.2" HIERA_GEM_VERSION="~> 1.3"
-  - rvm: 2.1.7
-    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.2" HIERA_GEM_VERSION="~> 1.3"
-  - rvm: 2.1.7
+  - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 3.8.5" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 1.3" FUTURE_PARSER="yes"
   - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.5.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.2.0"
+    env: PUPPET_GEM_VERSION="~> 4.5.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.3.0"
   - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.7.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.2.0"
+    env: PUPPET_GEM_VERSION="~> 4.7.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.3.0"
   - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.8.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.2.0"
+    env: PUPPET_GEM_VERSION="~> 4.8.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.3.0"
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.9.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.3.0"
   - rvm: 2.1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.9.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.3.0"
   - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.10.1" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.3.0"
+    env: PUPPET_GEM_VERSION="~> 4.10.4" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.3.0"
 
 deploy:
   provider: puppetforge
@@ -30,4 +30,4 @@ deploy:
     all_branches: true
     rvm: 2.1.9
     condition:
-    - $PUPPET_GEM_VERSION = '4.10.1'
+    - $PUPPET_GEM_VERSION = '4.10.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,28 +2,28 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    backports (3.6.8)
+    backports (3.8.0)
     coderay (1.0.9)
     diff-lcs (1.3)
     docile (1.1.5)
-    domain_name (0.5.20170223)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     ethon (0.10.1)
       ffi (>= 1.3.0)
     facter (2.4.6)
-    facterdb (0.3.10)
+    facterdb (0.3.11)
       facter
       jgrep
-    faraday (0.11.0)
+    faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.11.0.1)
       faraday (>= 0.7.4, < 1.0)
     fast_gettext (1.1.0)
     ffi (1.9.18)
-    gettext (3.2.2)
+    gettext (3.2.3)
       locale (>= 2.0.5)
       text (>= 1.3.0)
-    gettext-setup (0.18)
+    gettext-setup (0.25)
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2)
       locale
@@ -34,7 +34,7 @@ GEM
       multi_json (~> 1.0)
       net-http-persistent (~> 2.9)
       net-http-pipeline
-    hiera (3.2.2)
+    hiera (3.3.1)
     highline (1.7.8)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -45,7 +45,7 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     locale (2.1.2)
-    mcollective-client (2.10.2)
+    mcollective-client (2.10.4)
       json
       stomp
       systemu
@@ -67,10 +67,12 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.7)
       slop (>= 2.4.3, < 3)
-    puppet (4.7.0)
+    puppet (4.10.4)
       facter (> 2.0, < 4)
+      gettext-setup (>= 0.10, < 1)
       hiera (>= 2.0, < 4)
       json_pure (~> 1.8)
+      locale (~> 2.1)
     puppet-blacksmith (3.4.0)
       puppet (>= 2.7.16)
       rest-client (~> 1.8.0)
@@ -127,16 +129,16 @@ GEM
       mcollective-client
       puppet
     rspec-support (3.5.0)
-    semantic_puppet (0.1.4)
+    semantic_puppet (1.0.0)
       gettext-setup (>= 0.3)
     simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    simplecov-html (0.10.1)
     slop (2.4.4)
     spdx-licenses (1.1.0)
-    stomp (1.4.3)
+    stomp (1.4.4)
     systemu (2.6.5)
     text (1.3.1)
     travis (1.8.8)
@@ -154,7 +156,7 @@ GEM
       ethon (>= 0.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     websocket (1.2.4)
 
 PLATFORMS

--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.6.2 <5.0.0"
+      "version_requirement": ">=4.0.0 <5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Puppet 3 has been deprecated.
I want to remove support for it.
This will be a while in the making but worth it in the end.