### PR TITLE
Set correct parameters when upgrading to v4

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -27,7 +27,8 @@ class puppet::defaults {
     }
   }
 
-  if ( versioncmp($::puppetversion, '4.0.0') >= 0 ) {
+  # if we are currently running puppet v4 or upgrading to it
+  if versioncmp($::puppetversion, '4.0.0') >= 0 or $puppet::allinone {
     $server_type               = 'puppetserver'
     $confdir                   = '/etc/puppetlabs/puppet'
     $codedir                   = '/etc/puppetlabs/code'


### PR DESCRIPTION
This change covers 2 scenarios now
- currently running puppet v4
- upgrading to puppet v4

Fix for #158  