### PR TITLE
Add subsetting_key_val_separator to logdest (#161)

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -208,12 +208,13 @@ class puppet::config {
   }
 
   ini_subsetting { 'puppet sysconfig logdest':
-    ensure            => $logdest_ensure,
-    section           => '',
-    key_val_separator => '=',
-    path              => "${sysconfigdir}/puppet",
-    setting           => 'DAEMON_OPTS',
-    subsetting        => '--logdest',
-    value             => $logdest
+    ensure                       => $logdest_ensure,
+    section                      => '',
+    key_val_separator            => '=',
+    subsetting_key_val_separator => ' ',
+    path                         => "${sysconfigdir}/puppet",
+    setting                      => 'DAEMON_OPTS',
+    subsetting                   => '--logdest',
+    value                        => $logdest
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -61,7 +61,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">=1.2.0 <2.0.0"
+      "version_requirement": ">=1.2.0 <3.0.0"
     },
     {
       "name": "puppetlabs/puppetdb",

--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,7 @@
     },
     {
       "name": "puppet/puppetboard",
-      "version_requirement": ">=2.7.0 <3.0.0"
+      "version_requirement": ">=2.7.0 <5.0.0"
     },
     {
       "name": "puppetlabs/puppetserver_gem",

--- a/metadata.json
+++ b/metadata.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "puppetlabs/puppetdb",
-      "version_requirement": ">=5.0.0 <6.0.0"
+      "version_requirement": ">=5.0.0 <=7.0.1"
     },
     {
       "name": "puppet/r10k",

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">=1.4.0 <2.0.0"
+      "version_requirement": ">=1.4.0 <=3.2.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -57,7 +57,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.0.0 <3.0.0"
+      "version_requirement": ">=2.0.0 <5.0.0"
     },
     {
       "name": "puppetlabs/inifile",

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -183,6 +183,7 @@ describe 'puppet::config', :type => :class do
             'path'=>"#{sysconfigdir}/puppet",
             'section'=>'',
             'key_val_separator' => '=',
+            'subsetting_key_val_separator' => ' ',
             'setting'=>'DAEMON_OPTS',
             'subsetting'=>'--logdest',
             'value'=>'/var/log/BOGON'


### PR DESCRIPTION
ini_subsetting 'puppet sysconfig logdest' resource generates puppet
daemon option --logdest$logdest without delimeter