### PR TITLE
Bump upper limit of the apache and postgresql and puppetdb dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,13 +2,13 @@ fixtures:
   forge_modules:
     apache:
       repo: "puppetlabs/apache"
-      ref:  "1.4.1"
+      ref:  "2.3.0"
     concat:
       repo: "puppetlabs/concat"
       ref:  "1.2.2"
     stdlib:
       repo: "puppetlabs/stdlib"
-      ref:  "4.6.0"
+      ref:  "4.13.0"
     apt:
       repo: "puppetlabs/apt"
       ref:  "2.1.0"
@@ -17,10 +17,10 @@ fixtures:
       ref:  "1.2.0"
     postgresql:
       repo: "puppetlabs/postgresql"
-      ref:  "4.6.0"
+      ref:  "5.2.1"
     puppetdb:
       repo: "puppetlabs/puppetdb"
-      ref:  "5.0.0"
+      ref:  "6.0.2"
     firewall:
       repo: "puppetlabs/firewall"
       ref:  "1.5.0"

--- a/metadata.json
+++ b/metadata.json
@@ -61,7 +61,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">=1.2.0 <2.0.0"
+      "version_requirement": ">=1.2.0 <3.0.0"
     },
     {
       "name": "puppetlabs/puppetdb",

--- a/metadata.json
+++ b/metadata.json
@@ -49,15 +49,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">=1.4.0 <2.0.0"
+      "version_requirement": ">=1.4.0 <3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.6.0 <5.0.0"
+      "version_requirement": ">=4.13.0 <5.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.0.0 <3.0.0"
+      "version_requirement": ">=2.0.0 <5.0.0"
     },
     {
       "name": "puppetlabs/inifile",
@@ -65,7 +65,7 @@
     },
     {
       "name": "puppetlabs/puppetdb",
-      "version_requirement": ">=5.0.0 <6.0.0"
+      "version_requirement": ">=5.0.0 <7.0.0"
     },
     {
       "name": "puppet/r10k",
@@ -73,7 +73,7 @@
     },
     {
       "name": "puppet/puppetboard",
-      "version_requirement": ">=2.7.0 <3.0.0"
+      "version_requirement": ">=2.7.0 <5.0.0"
     },
     {
       "name": "puppetlabs/puppetserver_gem",


### PR DESCRIPTION
Change lower limit of stdlib dependency also to fix 'bug' in puppetdb module.