### PR TITLE
Bugfix logdest

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -230,6 +230,7 @@ class puppet::config {
     path              => "${sysconfigdir}/puppet",
     setting           => 'DAEMON_OPTS',
     subsetting        => '--logdest',
-    value             => $logdest
+    value             => $logdest,
+    subsetting_key_val_separator => '='
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -224,13 +224,13 @@ class puppet::config {
   }
 
   ini_subsetting { 'puppet sysconfig logdest':
-    ensure            => $logdest_ensure,
-    section           => '',
-    key_val_separator => '=',
-    path              => "${sysconfigdir}/puppet",
-    setting           => 'DAEMON_OPTS',
-    subsetting        => '--logdest',
-    value             => $logdest,
+    ensure                       => $logdest_ensure,
+    section                      => '',
+    key_val_separator            => '=',
+    path                         => "${sysconfigdir}/puppet",
+    setting                      => 'DAEMON_OPTS',
+    subsetting                   => '--logdest',
+    value                        => $logdest,
     subsetting_key_val_separator => '='
   }
 }

--- a/spec/classes/puppet_config_spec.rb
+++ b/spec/classes/puppet_config_spec.rb
@@ -210,7 +210,8 @@ describe 'puppet::config', :type => :class do
             'key_val_separator' => '=',
             'setting'=>'DAEMON_OPTS',
             'subsetting'=>'--logdest',
-            'value'=>'/var/log/BOGON'
+            'value'=>'/var/log/BOGON',
+            'subsetting_key_val_separator' => '='
           })
         end
       end# logdest


### PR DESCRIPTION
Adding subsetting_key_val_separator for logdest in puppet agent config which is injected empty string by default causing restarts to fails due to incorrect setting
original - '--logdest/var/log/puppetlabs/puppet/puppet.log'
proposed change - '--logdest /var/log/puppetlabs/puppet/puppet.log'