### PR TITLE
Add parameter to manage puppetmaster service status

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,10 @@ The `puppet::config` class is responsible for altering the configuration of `$co
 
   Specifies the type of server to use `puppetserver` is always used on Puppet 4
 
+  * **service_enable**: (*bool* Default: `true`)
+
+  Specifies if the puppetmaster service should be enabled
+
   * **module_path**: **DEPRECATED** (*string* Default: `undef`)
 
   If this is set, it will be used to populate the basemodulepath parameter in `/etc/puppet/puppet.conf`. This does not impact [environment.conf](http://docs.puppetlabs.com/puppet/latest/reference/config_file_environment.html), which should live in your [r10k](https://github.com/adrienthebo/r10k) environment repo.

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -74,8 +74,8 @@
 #   Specifies minute to run the report clean cronjob
 # @param report_clean_weekday ([String] Default: '0')
 #   Specifies weekday to run the report clean cronjob
-# @param service_ensure [String] Default: 'running'
-#   Specifies if the Puppet Master service should be running or stopped
+# @param service_enable [Boolean] Default: true
+#   Specifies if the Puppet Master service should be enabled
 # @param server_type ([String] Default Puppet 4: 'puppetserver' Default Puppet 4: 'passenger')
 #   Specifies the type of server to use puppetserver is always used on Puppet 4
 # @param $external_nodes ([String] Default undef)
@@ -127,7 +127,7 @@ class puppet::master (
   $report_clean_min                   = '22',
   $report_clean_hour                  = '21',
   $report_clean_weekday               = '0',
-  $service_ensure                     = 'running',
+  $service_enable                     = true,
   $server_type                        = $::puppet::defaults::server_type,
   $server_version                     = 'installed',
   $external_nodes                     = undef,

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -74,6 +74,8 @@
 #   Specifies minute to run the report clean cronjob
 # @param report_clean_weekday ([String] Default: '0')
 #   Specifies weekday to run the report clean cronjob
+# @param service_ensure [String] Default: 'running'
+#   Specifies if the Puppet Master service should be running or stopped
 # @param server_type ([String] Default Puppet 4: 'puppetserver' Default Puppet 4: 'passenger')
 #   Specifies the type of server to use puppetserver is always used on Puppet 4
 # @param $external_nodes ([String] Default undef)
@@ -125,6 +127,7 @@ class puppet::master (
   $report_clean_min                   = '22',
   $report_clean_hour                  = '21',
   $report_clean_weekday               = '0',
+  $service_ensure                     = 'running',
   $server_type                        = $::puppet::defaults::server_type,
   $server_version                     = 'installed',
   $external_nodes                     = undef,

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -21,6 +21,7 @@ class puppet::master::config {
   $report_clean_weekday = $puppet::master::report_clean_weekday
   $external_nodes       = $puppet::master::external_nodes
   $node_terminus        = $puppet::master::node_terminus
+  $service_ensure       = $puppet::master::service_ensure
 
   if ($ca_server != undef) {
     if ($ca_server == $::fqdn) {

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -21,7 +21,7 @@ class puppet::master::config {
   $report_clean_weekday = $puppet::master::report_clean_weekday
   $external_nodes       = $puppet::master::external_nodes
   $node_terminus        = $puppet::master::node_terminus
-  $service_ensure       = $puppet::master::service_ensure
+  $service_enable       = $puppet::master::service_enable
 
   if ($ca_server != undef) {
     if ($ca_server == $::fqdn) {

--- a/manifests/master/server.pp
+++ b/manifests/master/server.pp
@@ -5,7 +5,7 @@ class puppet::master::server {
   include ::puppet::defaults
   $sysconfigdir   = $::puppet::defaults::sysconfigdir
   $java_ram       = $::puppet::master::java_ram
-  $service_ensure = $::puppet::master::service_ensure
+  $service_enable = $::puppet::master::service_enable
 
   ini_subsetting { 'puppet server Xmx java_ram':
     ensure            => present,
@@ -30,8 +30,8 @@ class puppet::master::server {
   }
 
   service { 'puppetserver':
-    ensure    => $service_ensure,
-    enable    => true,
+    ensure    => $service_enable,
+    enable    => $service_enable,
     require   => Class[puppet::master::config],
     subscribe => [
       Class[puppet::master::hiera],

--- a/manifests/master/server.pp
+++ b/manifests/master/server.pp
@@ -3,8 +3,9 @@
 class puppet::master::server {
   include ::puppet::master
   include ::puppet::defaults
-  $sysconfigdir = $::puppet::defaults::sysconfigdir
-  $java_ram     = $::puppet::master::java_ram
+  $sysconfigdir   = $::puppet::defaults::sysconfigdir
+  $java_ram       = $::puppet::master::java_ram
+  $service_ensure = $::puppet::master::service_ensure
 
   ini_subsetting { 'puppet server Xmx java_ram':
     ensure            => present,
@@ -29,7 +30,7 @@ class puppet::master::server {
   }
 
   service { 'puppetserver':
-    ensure    => 'running',
+    ensure    => $service_ensure,
     enable    => true,
     require   => Class[puppet::master::config],
     subscribe => [

--- a/manifests/profile/master.pp
+++ b/manifests/profile/master.pp
@@ -51,6 +51,8 @@
 # @param java_ram ([String] Default: '2g')
 #   Set the ram to use for the new puppetserver
 # @param manage_deep_merge_package ([Boolean] Default: false)
+# @param service_ensure [String] Default: 'running'
+#   Specifies if the Puppet Master service should be running or stopped
 #   Whether the [deep_merge gem](https://rubygems.org/gems/deep_merge) should be installed.
 # @param manage_hiera_eyaml_package ([Boolean] Default: true)
 #   Whether the [hiera-eyaml gem](https://rubygems.org/gems/hiera-eyaml) should be installed.
@@ -146,6 +148,7 @@ class puppet::profile::master (
   $passenger_stat_throttle_rate       = '120',
   $puppet_fqdn                        = $::fqdn,
   $puppet_version                     = 'installed',
+  $service_ensure                     = 'running',
   $server_type                        = undef,
   $server_version                     = 'installed',
   $external_nodes                     = undef,
@@ -197,6 +200,7 @@ class puppet::profile::master (
     passenger_pool_idle_time           => $passenger_pool_idle_time,
     passenger_stat_throttle_rate       => $passenger_stat_throttle_rate,
     puppet_fqdn                        => $puppet_fqdn,
+    service_ensure                     => $service_ensure,
     server_version                     => $server_version,
     external_nodes                     => $external_nodes,
     node_terminus                      => $node_terminus,

--- a/manifests/profile/master.pp
+++ b/manifests/profile/master.pp
@@ -51,8 +51,8 @@
 # @param java_ram ([String] Default: '2g')
 #   Set the ram to use for the new puppetserver
 # @param manage_deep_merge_package ([Boolean] Default: false)
-# @param service_ensure [String] Default: 'running'
-#   Specifies if the Puppet Master service should be running or stopped
+# @param service_enable [Boolean] Default: true
+#   Specifies if the Puppet Master service should be enabled
 #   Whether the [deep_merge gem](https://rubygems.org/gems/deep_merge) should be installed.
 # @param manage_hiera_eyaml_package ([Boolean] Default: true)
 #   Whether the [hiera-eyaml gem](https://rubygems.org/gems/hiera-eyaml) should be installed.
@@ -148,7 +148,7 @@ class puppet::profile::master (
   $passenger_stat_throttle_rate       = '120',
   $puppet_fqdn                        = $::fqdn,
   $puppet_version                     = 'installed',
-  $service_ensure                     = 'running',
+  $service_enable                     = true,
   $server_type                        = undef,
   $server_version                     = 'installed',
   $external_nodes                     = undef,
@@ -200,7 +200,7 @@ class puppet::profile::master (
     passenger_pool_idle_time           => $passenger_pool_idle_time,
     passenger_stat_throttle_rate       => $passenger_stat_throttle_rate,
     puppet_fqdn                        => $puppet_fqdn,
-    service_ensure                     => $service_ensure,
+    service_enable                     => $service_enable,
     server_version                     => $server_version,
     external_nodes                     => $external_nodes,
     node_terminus                      => $node_terminus,

--- a/manifests/profile/master.pp
+++ b/manifests/profile/master.pp
@@ -51,8 +51,6 @@
 # @param java_ram ([String] Default: '2g')
 #   Set the ram to use for the new puppetserver
 # @param manage_deep_merge_package ([Boolean] Default: false)
-# @param service_enable [Boolean] Default: true
-#   Specifies if the Puppet Master service should be enabled
 #   Whether the [deep_merge gem](https://rubygems.org/gems/deep_merge) should be installed.
 # @param manage_hiera_eyaml_package ([Boolean] Default: true)
 #   Whether the [hiera-eyaml gem](https://rubygems.org/gems/hiera-eyaml) should be installed.
@@ -74,6 +72,8 @@
 #   Specifies the version of the puppetmaster package to install
 # @param server_type ([String] Default Puppet 4: 'puppetserver' Default Puppet 4: 'passenger')
 #   Specifies the type of server to use puppetserver is always used on Puppet 4
+# @param service_enable [Boolean] Default: true
+#   Specifies if the Puppet Master service should be enabled
 # @param $external_nodes ([String] Default undef)
 #   Specifies the script tom use as a node classifier
 # @param $node_terminus ([String] Default undef)
@@ -148,9 +148,9 @@ class puppet::profile::master (
   $passenger_stat_throttle_rate       = '120',
   $puppet_fqdn                        = $::fqdn,
   $puppet_version                     = 'installed',
-  $service_enable                     = true,
   $server_type                        = undef,
   $server_version                     = 'installed',
+  $service_enable                     = true,
   $external_nodes                     = undef,
   $node_terminus                      = undef,
   $puppetdb                           = false,
@@ -200,8 +200,8 @@ class puppet::profile::master (
     passenger_pool_idle_time           => $passenger_pool_idle_time,
     passenger_stat_throttle_rate       => $passenger_stat_throttle_rate,
     puppet_fqdn                        => $puppet_fqdn,
-    service_enable                     => $service_enable,
     server_version                     => $server_version,
+    service_enable                     => $service_enable,
     external_nodes                     => $external_nodes,
     node_terminus                      => $node_terminus,
     server_type                        => $server_type,

--- a/spec/classes/puppet_master_server_spec.rb
+++ b/spec/classes/puppet_master_server_spec.rb
@@ -71,7 +71,7 @@ describe 'puppet::master::server', :type => :class do
         end
         it 'should manage the puppet server service' do
           should contain_service('puppetserver').with({
-            'ensure'    => 'running',
+            'ensure'    => 'true',
             'enable'    => 'true'
           }).that_requires(
             'Class[puppet::master::config]'

--- a/spec/classes/puppet_master_spec.rb
+++ b/spec/classes/puppet_master_spec.rb
@@ -25,7 +25,7 @@ describe 'puppet::master', :type => :class do
       end
     end#arrays
 
-    ['autosign','eyaml_keys','future_parser'].each do |bools|
+    ['autosign','eyaml_keys','future_parser','service_enable'].each do |bools|
       context "when the #{bools} parameter is not an boolean" do
         let(:params) {{bools => "BOGON"}}
         it 'should fail' do


### PR DESCRIPTION
Add parameter to manage puppetmaster service status. This way the module can manage if puppetserver should be running or not.
By default will be running but it can be stopped if needed, for example when used on a docker instance.